### PR TITLE
docs: Fix the docstring of the field `n_samples` of `RunConfiguration`

### DIFF
--- a/src/gwsim_pop/config/run.py
+++ b/src/gwsim_pop/config/run.py
@@ -26,9 +26,9 @@ class RunConfiguration(BaseModel):
 
     n_samples: int = Field(
         default=1_000_000,
-        description="Number of samples. This is used when 'mode' is 'fixed_n_samples'.",
+        description="Number of samples. Only used when 'mode' is 'fixed_n_samples'.",
     )
-    """Number of samples. Set this to 0 when 'duration' is used to determine the number of samples."""
+    """Number of samples. Only used when 'mode' is 'fixed_n_samples'."""
 
     duration: float = Field(
         default=1.0, description="Duration in year (365 days). This is used when 'mode' is 'duration'."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `n_samples` configuration field description to explicitly specify it is only used when the mode is set to `fixed_n_samples`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->