### PR TITLE
feat: Add HDF5/CSV external population file reader

### DIFF
--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
+from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.version import __version__
 
-__all__ = ["ExternalPopulationLoader", "GWPopSimulator", "__version__"]
+__all__ = ["ExternalPopulationLoader", "FilePopulationLoader", "GWPopSimulator", "__version__"]

--- a/src/gwmock_pop/loaders/__init__.py
+++ b/src/gwmock_pop/loaders/__init__.py
@@ -1,0 +1,7 @@
+"""File-backed population catalogue loaders."""
+
+from __future__ import annotations
+
+from gwmock_pop.loaders.file_loader import FilePopulationLoader
+
+__all__ = ["FilePopulationLoader"]

--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -123,14 +123,32 @@ class FilePopulationLoader:
 
     @staticmethod
     def _read_hdf5_catalogue(path: Path, *, dataset_name: str) -> dict[str, Array]:
-        """Read a structured HDF5 dataset into a catalogue mapping."""
+        """Read an HDF5 catalogue from a compound dataset or group-of-datasets."""
         with h5py.File(path, "r") as handle:
-            dataset = handle[dataset_name]
-            if not isinstance(dataset, h5py.Dataset):
-                raise ValueError(f"HDF5 object '{dataset_name}' is not a dataset.")
-            data = np.atleast_1d(dataset[()])
-
-        return FilePopulationLoader._structured_array_to_catalogue(data, file_format="HDF5")
+            hdf5_object = handle[dataset_name]
+            if isinstance(hdf5_object, h5py.Dataset):
+                data = np.atleast_1d(hdf5_object[()])
+                return FilePopulationLoader._structured_array_to_catalogue(data, file_format="HDF5")
+            if isinstance(hdf5_object, h5py.Group):
+                group_catalogue: dict[str, np.ndarray] = {}
+                expected_length: int | None = None
+                for child_name, child_object in hdf5_object.items():
+                    if not isinstance(child_object, h5py.Dataset):
+                        raise ValueError(f"HDF5 group '{dataset_name}' contains non-dataset member '{child_name}'.")
+                    column = np.atleast_1d(child_object[()])
+                    if column.ndim != 1:
+                        raise ValueError(f"HDF5 group dataset '{dataset_name}/{child_name}' must be a 1-D array.")
+                    current_length = len(column)
+                    if expected_length is None:
+                        expected_length = current_length
+                    elif current_length != expected_length:
+                        raise ValueError(
+                            f"HDF5 group '{dataset_name}' has mismatched column lengths: "
+                            f"'{child_name}' has {current_length}, expected {expected_length}."
+                        )
+                    group_catalogue[child_name] = column
+                return FilePopulationLoader._structured_array_to_catalogue(group_catalogue, file_format="HDF5")
+            raise ValueError(f"HDF5 object '{dataset_name}' must be a dataset or a group of datasets.")
 
     @staticmethod
     def _read_csv_catalogue(path: Path) -> dict[str, Array]:
@@ -140,13 +158,20 @@ class FilePopulationLoader:
         return FilePopulationLoader._structured_array_to_catalogue(data, file_format="CSV")
 
     @staticmethod
-    def _structured_array_to_catalogue(data: np.ndarray, *, file_format: str) -> dict[str, Array]:
-        """Convert a structured array with named columns into JAX arrays."""
-        column_names = data.dtype.names
-        if column_names is None:
-            raise ValueError(f"{file_format} catalogue must provide named columns.")
+    def _structured_array_to_catalogue(
+        data: np.ndarray | Mapping[str, np.ndarray | Array], *, file_format: str
+    ) -> dict[str, Array]:
+        """Convert named-column data into a catalogue mapping of 1-D JAX arrays."""
+        if isinstance(data, Mapping):
+            catalogue = {name: jnp.asarray(np.atleast_1d(values)) for name, values in data.items()}
+        else:
+            column_names = data.dtype.names
+            if column_names is None:
+                raise ValueError(f"{file_format} catalogue must provide named columns.")
+            catalogue = {name: jnp.asarray(np.atleast_1d(data[name])) for name in column_names}
 
-        catalogue = {name: jnp.asarray(np.atleast_1d(data[name])) for name in column_names}
+        if not catalogue:
+            raise ValueError(f"{file_format} catalogue is empty.")
         if any(values.ndim != 1 for values in catalogue.values()):
             raise ValueError(f"{file_format} catalogue columns must be 1-D arrays.")
         return catalogue

--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import h5py
 import jax
@@ -82,27 +83,30 @@ class FilePopulationLoader:
         """
         return self._source_type
 
-    def simulate(self, n_samples: int, *, seed: int | None = None) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
         """Sample catalogue rows without replacement.
 
         Args:
             n_samples: Number of catalogue rows to draw.
-            seed: Optional integer seed for the JAX PRNG. If omitted, a
-                deterministic default seed of ``0`` is used.
+            **kwargs: Optional backend-agnostic random-state hints. Supported
+                keys include ``seed``, ``key``, and ``rng`` (in that priority).
 
         Returns:
             Mapping from parameter name to a 1-D ``jax.Array`` of sampled
             values.
 
         Raises:
-            ValueError: If ``n_samples`` exceeds the number of rows in the
-                loaded catalogue.
+            ValueError: If ``n_samples`` is negative or exceeds the number of
+                rows in the loaded catalogue.
         """
         catalogue_size = len(next(iter(self._catalogue.values())))
+        if n_samples < 0:
+            raise ValueError(f"n_samples must be >= 0, got {n_samples}.")
         if n_samples > catalogue_size:
             raise ValueError(f"Requested {n_samples} samples from a catalogue with only {catalogue_size} rows.")
 
-        key = jax.random.PRNGKey(0 if seed is None else seed)
+        seed = kwargs.get("seed", kwargs.get("key", kwargs.get("rng")))
+        key = jax.random.PRNGKey(0 if seed is None else int(seed))
         indices = jax.random.choice(key, catalogue_size, shape=(n_samples,), replace=False)
         return {name: self._catalogue[name][indices] for name in self._parameter_names}
 

--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -1,0 +1,163 @@
+"""Concrete external population loader for file-backed catalogues."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+import h5py
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+
+
+class FilePopulationLoader:
+    """Load an external population catalogue from HDF5 or CSV.
+
+    The loader reads the input file eagerly during construction, normalizes the
+    catalogue into a mapping of 1-D ``jax.Array`` columns, and then provides a
+    :meth:`simulate` method that samples catalogue rows without replacement.
+    This keeps the runtime surface compatible with
+    :class:`gwmock_pop.protocols.ExternalPopulationLoader` and
+    :class:`gwmock_pop.protocols.GWPopSimulator` without introducing a shared
+    inheritance hierarchy.
+    """
+
+    def __init__(
+        self,
+        source_type: str,
+        path: str | os.PathLike,
+        *,
+        column_map: dict[str, str] | None = None,
+        hdf5_dataset: str = "data",
+    ) -> None:
+        """Load and validate a population catalogue from disk.
+
+        Args:
+            source_type: Non-empty routing key used by downstream simulators,
+                such as ``"bbh"`` or ``"bns"``.
+            path: Path to the input catalogue file. Supported formats are
+                ``.hdf5``, ``.h5``, and ``.csv``.
+            column_map: Optional mapping from file column names to canonical
+                gwmock-pop parameter names. Keys must exist in the loaded
+                catalogue.
+            hdf5_dataset: Dataset name to read from HDF5 files.
+
+        Raises:
+            ValueError: If ``source_type`` is empty, the file format is
+                unsupported, the file contents do not expose named columns, the
+                column mapping is invalid, or the resulting catalogue is empty.
+        """
+        if not source_type:
+            raise ValueError("source_type must be a non-empty string.")
+
+        self._source_type = source_type
+        self._path = Path(path)
+
+        catalogue = self._read_catalogue(self._path, hdf5_dataset=hdf5_dataset)
+        self._catalogue = self._apply_column_map(catalogue, column_map or {})
+
+        if not self._catalogue:
+            raise ValueError("Loaded catalogue is empty.")
+
+        self._parameter_names = sorted(self._catalogue)
+
+    @property
+    def parameter_names(self) -> list[str]:
+        """Return the stable ordered parameter names exposed by this loader.
+
+        Returns:
+            Sorted list of parameter names available in the loaded catalogue.
+        """
+        return self._parameter_names
+
+    @property
+    def source_type(self) -> str:
+        """Return the routing key associated with this population catalogue.
+
+        Returns:
+            Source type passed at construction time.
+        """
+        return self._source_type
+
+    def simulate(self, n_samples: int, *, seed: int | None = None) -> Mapping[str, Array]:
+        """Sample catalogue rows without replacement.
+
+        Args:
+            n_samples: Number of catalogue rows to draw.
+            seed: Optional integer seed for the JAX PRNG. If omitted, a
+                deterministic default seed of ``0`` is used.
+
+        Returns:
+            Mapping from parameter name to a 1-D ``jax.Array`` of sampled
+            values.
+
+        Raises:
+            ValueError: If ``n_samples`` exceeds the number of rows in the
+                loaded catalogue.
+        """
+        catalogue_size = len(next(iter(self._catalogue.values())))
+        if n_samples > catalogue_size:
+            raise ValueError(f"Requested {n_samples} samples from a catalogue with only {catalogue_size} rows.")
+
+        key = jax.random.PRNGKey(0 if seed is None else seed)
+        indices = jax.random.choice(key, catalogue_size, shape=(n_samples,), replace=False)
+        return {name: self._catalogue[name][indices] for name in self._parameter_names}
+
+    @staticmethod
+    def _read_catalogue(path: Path, *, hdf5_dataset: str) -> dict[str, Array]:
+        """Read a named-column catalogue from an HDF5 or CSV file."""
+        suffix = path.suffix.lower()
+        if suffix in {".hdf5", ".h5"}:
+            return FilePopulationLoader._read_hdf5_catalogue(path, dataset_name=hdf5_dataset)
+        if suffix == ".csv":
+            return FilePopulationLoader._read_csv_catalogue(path)
+
+        raise ValueError("Unsupported file format. Supported formats are: .hdf5, .h5, .csv.")
+
+    @staticmethod
+    def _read_hdf5_catalogue(path: Path, *, dataset_name: str) -> dict[str, Array]:
+        """Read a structured HDF5 dataset into a catalogue mapping."""
+        with h5py.File(path, "r") as handle:
+            dataset = handle[dataset_name]
+            if not isinstance(dataset, h5py.Dataset):
+                raise ValueError(f"HDF5 object '{dataset_name}' is not a dataset.")
+            data = np.atleast_1d(dataset[()])
+
+        return FilePopulationLoader._structured_array_to_catalogue(data, file_format="HDF5")
+
+    @staticmethod
+    def _read_csv_catalogue(path: Path) -> dict[str, Array]:
+        """Read a header-based CSV file into a catalogue mapping."""
+        data = np.genfromtxt(path, delimiter=",", names=True, dtype=None, encoding=None)
+        data = np.atleast_1d(data)
+        return FilePopulationLoader._structured_array_to_catalogue(data, file_format="CSV")
+
+    @staticmethod
+    def _structured_array_to_catalogue(data: np.ndarray, *, file_format: str) -> dict[str, Array]:
+        """Convert a structured array with named columns into JAX arrays."""
+        column_names = data.dtype.names
+        if column_names is None:
+            raise ValueError(f"{file_format} catalogue must provide named columns.")
+
+        catalogue = {name: jnp.asarray(np.atleast_1d(data[name])) for name in column_names}
+        if any(values.ndim != 1 for values in catalogue.values()):
+            raise ValueError(f"{file_format} catalogue columns must be 1-D arrays.")
+        return catalogue
+
+    @staticmethod
+    def _apply_column_map(catalogue: dict[str, Array], column_map: dict[str, str]) -> dict[str, Array]:
+        """Apply a deterministic column renaming map to a catalogue mapping."""
+        unknown_columns = sorted(set(column_map) - set(catalogue))
+        if unknown_columns:
+            raise ValueError(f"Column map references unknown columns: {unknown_columns}")
+
+        remapped_catalogue: dict[str, Array] = {}
+        for source_name, values in catalogue.items():
+            target_name = column_map.get(source_name, source_name)
+            if target_name in remapped_catalogue:
+                raise ValueError(f"Column mapping produces duplicate output column '{target_name}'.")
+            remapped_catalogue[target_name] = values
+        return remapped_catalogue

--- a/tests/loaders/__init__.py
+++ b/tests/loaders/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for file-backed loaders."""

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -36,6 +36,14 @@ def _write_hdf5_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
         handle.create_dataset("data", data=structured)
 
 
+def _write_hdf5_group_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
+    """Write an HDF5 group where each column is its own dataset."""
+    with h5py.File(path, "w") as handle:
+        group = handle.create_group("data")
+        for name, values in columns.items():
+            group.create_dataset(name, data=values)
+
+
 def _write_csv_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
     """Write a header-based CSV file with named columns."""
     matrix = np.column_stack([columns[name] for name in columns])
@@ -70,6 +78,21 @@ def test_csv_round_trip(tmp_path: Path) -> None:
     assert list(result.keys()) == loader.parameter_names
     assert set(result) == set(columns)
     assert all(array.shape == (50,) for array in result.values())
+
+
+def test_hdf5_group_round_trip(tmp_path: Path) -> None:
+    """Load an HDF5 group-of-datasets catalogue and sample rows."""
+    path = tmp_path / "catalogue_group.hdf5"
+    columns = _catalogue_columns()
+    _write_hdf5_group_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(40, seed=13)
+
+    assert isinstance(loader, GWPopSimulator)
+    assert list(result.keys()) == loader.parameter_names
+    assert set(result) == set(columns)
+    assert all(array.shape == (40,) for array in result.values())
 
 
 def test_column_map_renames_keys(tmp_path: Path) -> None:
@@ -137,6 +160,18 @@ def test_simulate_accepts_backend_agnostic_kwargs(tmp_path: Path) -> None:
 
     assert list(result.keys()) == loader.parameter_names
     assert all(array.shape == (10,) for array in result.values())
+
+
+def test_hdf5_group_mismatched_column_lengths_raise(tmp_path: Path) -> None:
+    """Reject group-of-datasets catalogues with inconsistent column lengths."""
+    path = tmp_path / "catalogue_bad_group.hdf5"
+    with h5py.File(path, "w") as handle:
+        group = handle.create_group("data")
+        group.create_dataset("mass_1", data=np.linspace(30.0, 60.0, 20))
+        group.create_dataset("mass_2", data=np.linspace(20.0, 40.0, 19))
+
+    with pytest.raises(ValueError, match="mismatched column lengths"):
+        FilePopulationLoader("bbh", path)
 
 
 def test_unsupported_format_raises(tmp_path: Path) -> None:

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -1,0 +1,123 @@
+"""Integration tests for ``FilePopulationLoader``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from gwmock_pop import FilePopulationLoader
+from gwmock_pop.protocols import GWPopSimulator
+
+pytestmark = pytest.mark.integration
+
+
+def _catalogue_columns(n_rows: int = 200) -> dict[str, np.ndarray]:
+    """Create a deterministic synthetic catalogue."""
+    return {
+        "mass_1": np.linspace(30.0, 60.0, n_rows),
+        "mass_2": np.linspace(20.0, 40.0, n_rows),
+        "redshift": np.linspace(0.05, 1.0, n_rows),
+        "distance": np.linspace(100.0, 1000.0, n_rows),
+        "spin_1z": np.linspace(-0.9, 0.9, n_rows),
+    }
+
+
+def _write_hdf5_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
+    """Write a structured HDF5 dataset with named columns."""
+    dtype = [(name, np.float64) for name in columns]
+    structured = np.zeros(len(next(iter(columns.values()))), dtype=dtype)
+    for name, values in columns.items():
+        structured[name] = values
+
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset("data", data=structured)
+
+
+def _write_csv_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
+    """Write a header-based CSV file with named columns."""
+    matrix = np.column_stack([columns[name] for name in columns])
+    np.savetxt(path, matrix, delimiter=",", header=",".join(columns), comments="")
+
+
+def test_hdf5_round_trip(tmp_path: Path) -> None:
+    """Load an HDF5 catalogue and sample rows through the protocol surface."""
+    path = tmp_path / "catalogue.hdf5"
+    columns = _catalogue_columns()
+    _write_hdf5_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(50, seed=123)
+
+    assert isinstance(loader, GWPopSimulator)
+    assert list(result.keys()) == loader.parameter_names
+    assert set(result) == set(columns)
+    assert all(array.shape == (50,) for array in result.values())
+
+
+def test_csv_round_trip(tmp_path: Path) -> None:
+    """Load a CSV catalogue and sample rows through the protocol surface."""
+    path = tmp_path / "catalogue.csv"
+    columns = _catalogue_columns()
+    _write_csv_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(50, seed=123)
+
+    assert isinstance(loader, GWPopSimulator)
+    assert list(result.keys()) == loader.parameter_names
+    assert set(result) == set(columns)
+    assert all(array.shape == (50,) for array in result.values())
+
+
+def test_column_map_renames_keys(tmp_path: Path) -> None:
+    """Apply a column mapping and expose only canonical names."""
+    path = tmp_path / "catalogue.csv"
+    columns = {
+        "m1": np.linspace(30.0, 60.0, 200),
+        "m2": np.linspace(20.0, 40.0, 200),
+        "z": np.linspace(0.05, 1.0, 200),
+        "distance": np.linspace(100.0, 1000.0, 200),
+        "spin1z": np.linspace(-0.9, 0.9, 200),
+    }
+    _write_csv_catalogue(path, columns)
+
+    loader = FilePopulationLoader(
+        "bbh",
+        path,
+        column_map={"m1": "mass_1", "m2": "mass_2", "z": "redshift", "spin1z": "spin_1z"},
+    )
+    result = loader.simulate(25, seed=9)
+
+    assert "m1" not in loader.parameter_names
+    assert "m2" not in loader.parameter_names
+    assert "z" not in loader.parameter_names
+    assert "spin1z" not in loader.parameter_names
+    assert "mass_1" in loader.parameter_names
+    assert "mass_2" in loader.parameter_names
+    assert "redshift" in loader.parameter_names
+    assert "spin_1z" in loader.parameter_names
+    assert list(result.keys()) == loader.parameter_names
+
+
+def test_simulate_exceeds_catalogue_raises(tmp_path: Path) -> None:
+    """Reject sample requests larger than the catalogue."""
+    path = tmp_path / "catalogue.csv"
+    columns = _catalogue_columns(n_rows=20)
+    _write_csv_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+
+    with pytest.raises(ValueError, match="Requested 21 samples"):
+        loader.simulate(21)
+
+
+def test_unsupported_format_raises(tmp_path: Path) -> None:
+    """Reject unsupported file extensions at construction time."""
+    path = tmp_path / "catalogue.fits"
+    path.write_text("not-a-supported-catalogue\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"Supported formats are: \.hdf5, \.h5, \.csv"):
+        FilePopulationLoader("bbh", path)

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -114,6 +114,31 @@ def test_simulate_exceeds_catalogue_raises(tmp_path: Path) -> None:
         loader.simulate(21)
 
 
+def test_simulate_negative_n_samples_raises(tmp_path: Path) -> None:
+    """Reject negative sample counts."""
+    path = tmp_path / "catalogue.csv"
+    columns = _catalogue_columns(n_rows=20)
+    _write_csv_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+
+    with pytest.raises(ValueError, match=r"n_samples must be >= 0"):
+        loader.simulate(-1)
+
+
+def test_simulate_accepts_backend_agnostic_kwargs(tmp_path: Path) -> None:
+    """Accept alternative random-state kwargs without rejecting the call."""
+    path = tmp_path / "catalogue.csv"
+    columns = _catalogue_columns()
+    _write_csv_catalogue(path, columns)
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(10, rng=42, unknown_backend_kwarg=True)
+
+    assert list(result.keys()) == loader.parameter_names
+    assert all(array.shape == (10,) for array in result.values())
+
+
 def test_unsupported_format_raises(tmp_path: Path) -> None:
     """Reject unsupported file extensions at construction time."""
     path = tmp_path / "catalogue.fits"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a file-backed population loader supporting HDF5 and CSV, with optional column-name mapping, input validation, deterministic sampling, and a stable parameter-name interface.
  * Made the new loader publicly importable from the package root and the loaders subpackage.

* **Tests**
  * Added integration tests covering formats, column-mapping behavior, sampling correctness, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->