### PR TITLE
chore: Add GWTC-era power-law-plus-Gaussian-peak primary mass model

### DIFF
--- a/.coderabbitai.yaml
+++ b/.coderabbitai.yaml
@@ -1,0 +1,3 @@
+reviews:
+    auto_review:
+        enabled: false

--- a/src/gwmock_pop/configs/__init__.py
+++ b/src/gwmock_pop/configs/__init__.py
@@ -1,0 +1,1 @@
+"""Packaged graph-simulator preset configurations."""

--- a/src/gwmock_pop/configs/bbh_power_law_plus_peak.yaml
+++ b/src/gwmock_pop/configs/bbh_power_law_plus_peak.yaml
@@ -1,0 +1,27 @@
+parameters:
+    detector_frame_mass_1:
+        sampler:
+            function: power_law_plus_peak
+            arguments:
+                alpha: 2.63
+                minimum: 4.59
+                maximum: 86.22
+                lambda_peak: 0.10
+                peak_mean: 33.07
+                peak_sigma: 5.69
+                peak_maximum: 100.0
+    mass_ratio:
+        intermediate: true
+        sampler:
+            function: mass_ratio_pairing
+            arguments:
+                primary_mass: '@detector_frame_mass_1'
+                beta: 1.26
+                secondary_minimum: 4.59
+                minimum: 0.0
+    detector_frame_mass_2:
+        transform:
+            function: multiply
+            arguments:
+                left: '@detector_frame_mass_1'
+                right: '@mass_ratio'

--- a/src/gwmock_pop/distributions/__init__.py
+++ b/src/gwmock_pop/distributions/__init__.py
@@ -7,11 +7,17 @@ from gwmock_pop.distributions.broken_power_law import (
     broken_power_law_logpdf,
     broken_power_law_unnormalized_logpdf,
 )
+from gwmock_pop.distributions.mass_ratio_pairing import mass_ratio_pairing_cdf, mass_ratio_pairing_pdf
+from gwmock_pop.distributions.power_law_plus_peak import power_law_plus_peak_cdf, power_law_plus_peak_pdf
 from gwmock_pop.distributions.smoothing import planck_tapering_function
 
 __all__ = [
     "broken_power_law_log_normalization_constant",
     "broken_power_law_logpdf",
     "broken_power_law_unnormalized_logpdf",
+    "mass_ratio_pairing_cdf",
+    "mass_ratio_pairing_pdf",
     "planck_tapering_function",
+    "power_law_plus_peak_cdf",
+    "power_law_plus_peak_pdf",
 ]

--- a/src/gwmock_pop/distributions/mass_ratio_pairing.py
+++ b/src/gwmock_pop/distributions/mass_ratio_pairing.py
@@ -11,6 +11,7 @@ def _effective_minimum_mass_ratio(primary_mass: Array, secondary_minimum: float,
     """Return the support lower bound for the conditional mass ratio."""
     primary_mass_array = jnp.asarray(primary_mass)
     checkify.check(jnp.all(primary_mass_array > 0.0), "primary_mass must be strictly positive.")
+    checkify.check(secondary_minimum > 0.0, "secondary_minimum must be strictly positive.")
     return jnp.maximum(minimum, secondary_minimum / primary_mass_array)
 
 

--- a/src/gwmock_pop/distributions/mass_ratio_pairing.py
+++ b/src/gwmock_pop/distributions/mass_ratio_pairing.py
@@ -1,0 +1,78 @@
+"""Conditional mass-ratio pairing distribution helpers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+from jax.experimental import checkify
+
+
+def _effective_minimum_mass_ratio(primary_mass: Array, secondary_minimum: float, minimum: float) -> Array:
+    """Return the support lower bound for the conditional mass ratio."""
+    primary_mass_array = jnp.asarray(primary_mass)
+    checkify.check(jnp.all(primary_mass_array > 0.0), "primary_mass must be strictly positive.")
+    return jnp.maximum(minimum, secondary_minimum / primary_mass_array)
+
+
+def mass_ratio_pairing_pdf(
+    mass_ratio: Array,
+    primary_mass: Array,
+    beta: float,
+    secondary_minimum: float,
+    minimum: float = 0.0,
+) -> Array:
+    """Return the normalized conditional pairing density ``p(q | m1)``."""
+    lower = _effective_minimum_mass_ratio(
+        primary_mass=primary_mass,
+        secondary_minimum=secondary_minimum,
+        minimum=minimum,
+    )
+    checkify.check(jnp.all(lower < 1.0), "mass-ratio support is empty for at least one primary mass.")
+    return _power_law_mass_ratio_pdf(mass_ratio=mass_ratio, beta=beta, lower=lower)
+
+
+def mass_ratio_pairing_cdf(
+    mass_ratio: Array,
+    primary_mass: Array,
+    beta: float,
+    secondary_minimum: float,
+    minimum: float = 0.0,
+) -> Array:
+    """Return the normalized conditional pairing CDF ``P(q' <= q | m1)``."""
+    lower = _effective_minimum_mass_ratio(
+        primary_mass=primary_mass,
+        secondary_minimum=secondary_minimum,
+        minimum=minimum,
+    )
+    checkify.check(jnp.all(lower < 1.0), "mass-ratio support is empty for at least one primary mass.")
+
+    mass_ratio_array, lower_array = jnp.broadcast_arrays(jnp.asarray(mass_ratio), lower)
+    clipped = jnp.clip(mass_ratio_array, lower_array, 1.0)
+    support = (mass_ratio_array >= lower_array) & (mass_ratio_array <= 1.0)
+    if jnp.isclose(beta, -1.0):
+        numerator = jnp.log(clipped / lower_array)
+        denominator = jnp.log(1.0 / lower_array)
+    else:
+        exponent = beta + 1.0
+        numerator = clipped**exponent - lower_array**exponent
+        denominator = 1.0 - lower_array**exponent
+    cdf = numerator / denominator
+    return jnp.where(
+        mass_ratio_array < lower_array,
+        0.0,
+        jnp.where(mass_ratio_array > 1.0, 1.0, jnp.where(support, cdf, 0.0)),
+    )
+
+
+def _power_law_mass_ratio_pdf(mass_ratio: Array, beta: float, lower: Array) -> Array:
+    """Return the normalized ``q**beta`` density on ``[lower, 1]``."""
+    mass_ratio_array, lower_array = jnp.broadcast_arrays(jnp.asarray(mass_ratio), lower)
+    support = (mass_ratio_array >= lower_array) & (mass_ratio_array <= 1.0)
+    if jnp.isclose(beta, -1.0):
+        normalization = jnp.log(1.0 / lower_array)
+        density = 1.0 / (mass_ratio_array * normalization)
+    else:
+        exponent = beta + 1.0
+        normalization = 1.0 - lower_array**exponent
+        density = exponent * mass_ratio_array**beta / normalization
+    return jnp.where(support, density, 0.0)

--- a/src/gwmock_pop/distributions/power_law_plus_peak.py
+++ b/src/gwmock_pop/distributions/power_law_plus_peak.py
@@ -1,0 +1,120 @@
+"""Power-law-plus-peak primary-mass distribution helpers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+from jax.experimental import checkify
+from jax.scipy.special import erf
+
+_SQRT_TWO = jnp.sqrt(2.0)
+_SQRT_TWO_PI = jnp.sqrt(2.0 * jnp.pi)
+
+
+def _standard_normal_cdf(x: Array) -> Array:
+    """Return the standard normal cumulative distribution function."""
+    return 0.5 * (1.0 + erf(x / _SQRT_TWO))
+
+
+def _power_law_pdf(mass: Array, alpha: float, minimum: float, maximum: float) -> Array:
+    """Return the normalized power-law density on ``[minimum, maximum]``."""
+    support = (mass >= minimum) & (mass <= maximum)
+    if jnp.isclose(alpha, 1.0):
+        normalization = jnp.log(maximum / minimum)
+        density = 1.0 / (mass * normalization)
+    else:
+        exponent = 1.0 - alpha
+        normalization = maximum**exponent - minimum**exponent
+        density = exponent * mass ** (-alpha) / normalization
+    return jnp.where(support, density, 0.0)
+
+
+def _power_law_cdf(mass: Array, alpha: float, minimum: float, maximum: float) -> Array:
+    """Return the normalized power-law CDF on ``[minimum, maximum]``."""
+    clipped_mass = jnp.clip(mass, minimum, maximum)
+    if jnp.isclose(alpha, 1.0):
+        normalization = jnp.log(maximum / minimum)
+        cdf = jnp.log(clipped_mass / minimum) / normalization
+    else:
+        exponent = 1.0 - alpha
+        normalization = maximum**exponent - minimum**exponent
+        cdf = (clipped_mass**exponent - minimum**exponent) / normalization
+    return jnp.where(mass < minimum, 0.0, jnp.where(mass > maximum, 1.0, cdf))
+
+
+def _truncated_normal_pdf(mass: Array, mean: float, sigma: float, minimum: float, maximum: float) -> Array:
+    """Return the normalized truncated-normal density on ``[minimum, maximum]``."""
+    support = (mass >= minimum) & (mass <= maximum)
+    lower = (minimum - mean) / sigma
+    upper = (maximum - mean) / sigma
+    normalization = _standard_normal_cdf(upper) - _standard_normal_cdf(lower)
+    z = (mass - mean) / sigma
+    density = jnp.exp(-0.5 * z**2) / (sigma * _SQRT_TWO_PI * normalization)
+    return jnp.where(support, density, 0.0)
+
+
+def _truncated_normal_cdf(mass: Array, mean: float, sigma: float, minimum: float, maximum: float) -> Array:
+    """Return the normalized truncated-normal CDF on ``[minimum, maximum]``."""
+    clipped_mass = jnp.clip(mass, minimum, maximum)
+    lower = (minimum - mean) / sigma
+    upper = (maximum - mean) / sigma
+    normalization = _standard_normal_cdf(upper) - _standard_normal_cdf(lower)
+    z = (clipped_mass - mean) / sigma
+    cdf = (_standard_normal_cdf(z) - _standard_normal_cdf(lower)) / normalization
+    return jnp.where(mass < minimum, 0.0, jnp.where(mass > maximum, 1.0, cdf))
+
+
+def power_law_plus_peak_pdf(  # noqa: PLR0913
+    mass: Array,
+    alpha: float,
+    minimum: float,
+    maximum: float,
+    lambda_peak: float,
+    peak_mean: float,
+    peak_sigma: float,
+    peak_maximum: float,
+) -> Array:
+    """Return the normalized Talbot-Thrane-style power-law-plus-peak density."""
+    checkify.check(minimum < maximum, "minimum must be strictly less than maximum.")
+    checkify.check(minimum < peak_maximum, "minimum must be strictly less than peak_maximum.")
+    checkify.check(lambda_peak >= 0.0, "lambda_peak must be non-negative.")
+    checkify.check(lambda_peak <= 1.0, "lambda_peak must be at most 1.")
+    checkify.check(peak_sigma > 0.0, "peak_sigma must be strictly positive.")
+
+    power_law_component = _power_law_pdf(mass=mass, alpha=alpha, minimum=minimum, maximum=maximum)
+    peak_component = _truncated_normal_pdf(
+        mass=mass,
+        mean=peak_mean,
+        sigma=peak_sigma,
+        minimum=minimum,
+        maximum=peak_maximum,
+    )
+    return (1.0 - lambda_peak) * power_law_component + lambda_peak * peak_component
+
+
+def power_law_plus_peak_cdf(  # noqa: PLR0913
+    mass: Array,
+    alpha: float,
+    minimum: float,
+    maximum: float,
+    lambda_peak: float,
+    peak_mean: float,
+    peak_sigma: float,
+    peak_maximum: float,
+) -> Array:
+    """Return the normalized Talbot-Thrane-style power-law-plus-peak CDF."""
+    checkify.check(minimum < maximum, "minimum must be strictly less than maximum.")
+    checkify.check(minimum < peak_maximum, "minimum must be strictly less than peak_maximum.")
+    checkify.check(lambda_peak >= 0.0, "lambda_peak must be non-negative.")
+    checkify.check(lambda_peak <= 1.0, "lambda_peak must be at most 1.")
+    checkify.check(peak_sigma > 0.0, "peak_sigma must be strictly positive.")
+
+    power_law_component = _power_law_cdf(mass=mass, alpha=alpha, minimum=minimum, maximum=maximum)
+    peak_component = _truncated_normal_cdf(
+        mass=mass,
+        mean=peak_mean,
+        sigma=peak_sigma,
+        minimum=minimum,
+        maximum=peak_maximum,
+    )
+    return (1.0 - lambda_peak) * power_law_component + lambda_peak * peak_component

--- a/src/gwmock_pop/samplers/__init__.py
+++ b/src/gwmock_pop/samplers/__init__.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+from gwmock_pop.samplers.mass_ratio_pairing import mass_ratio_pairing
 from gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks import (
     planck_tapered_broken_power_law_plus_two_peaks,
 )
 from gwmock_pop.samplers.planck_tapered_conditional_ratio_power_law import planck_tapered_conditional_ratio_power_law
+from gwmock_pop.samplers.power_law_plus_peak import power_law_plus_peak
 
-__all__ = ["planck_tapered_broken_power_law_plus_two_peaks", "planck_tapered_conditional_ratio_power_law"]
+__all__ = [
+    "mass_ratio_pairing",
+    "planck_tapered_broken_power_law_plus_two_peaks",
+    "planck_tapered_conditional_ratio_power_law",
+    "power_law_plus_peak",
+]

--- a/src/gwmock_pop/samplers/mass_ratio_pairing.py
+++ b/src/gwmock_pop/samplers/mass_ratio_pairing.py
@@ -1,0 +1,45 @@
+"""Sampler for the conditional mass-ratio pairing function."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jax.experimental import checkify
+
+
+def mass_ratio_pairing(  # noqa: PLR0913
+    key: Array,
+    primary_mass: Array,
+    beta: float,
+    secondary_minimum: float,
+    minimum: float = 0.0,
+    n_samples: int | None = None,
+) -> Array:
+    """Draw one conditional mass ratio per primary mass."""
+    primary_mass_array = jnp.asarray(primary_mass)
+
+    if primary_mass_array.ndim == 0:
+        if n_samples is None:
+            raise ValueError("n_samples is required when primary_mass is scalar.")
+        target_shape = (n_samples,)
+        primary_mass_array = jnp.full(shape=target_shape, fill_value=primary_mass_array)
+    else:
+        target_shape = primary_mass_array.shape
+        if n_samples is not None:
+            checkify.check(target_shape[0] == n_samples, "n_samples must match the leading dimension of primary_mass.")
+
+    lower = jnp.maximum(minimum, secondary_minimum / primary_mass_array)
+    checkify.check(jnp.all(lower < 1.0), "mass-ratio support is empty for at least one primary mass.")
+
+    uniform = jax.random.uniform(key, shape=target_shape)
+    return _inverse_mass_ratio_pairing_cdf(uniform=uniform, beta=beta, lower=lower)
+
+
+def _inverse_mass_ratio_pairing_cdf(uniform: Array, beta: float, lower: Array) -> Array:
+    """Invert the normalized pairing CDF analytically."""
+    if jnp.isclose(beta, -1.0):
+        return lower * jnp.exp(uniform * jnp.log(1.0 / lower))
+
+    exponent = beta + 1.0
+    return (lower**exponent + uniform * (1.0 - lower**exponent)) ** (1.0 / exponent)

--- a/src/gwmock_pop/samplers/mass_ratio_pairing.py
+++ b/src/gwmock_pop/samplers/mass_ratio_pairing.py
@@ -17,6 +17,7 @@ def mass_ratio_pairing(  # noqa: PLR0913
     n_samples: int | None = None,
 ) -> Array:
     """Draw one conditional mass ratio per primary mass."""
+    checkify.check(secondary_minimum > 0.0, "secondary_minimum must be strictly positive.")
     primary_mass_array = jnp.asarray(primary_mass)
 
     if primary_mass_array.ndim == 0:

--- a/src/gwmock_pop/samplers/power_law_plus_peak.py
+++ b/src/gwmock_pop/samplers/power_law_plus_peak.py
@@ -1,0 +1,68 @@
+"""Sampler for the Talbot-Thrane power-law-plus-peak primary-mass model."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jax.experimental import checkify
+
+
+def power_law_plus_peak(  # noqa: PLR0913
+    key: Array,
+    n_samples: int,
+    alpha: float,
+    minimum: float,
+    maximum: float,
+    lambda_peak: float,
+    peak_mean: float,
+    peak_sigma: float,
+    peak_maximum: float,
+) -> Array:
+    """Draw primary masses from a power law plus truncated Gaussian peak."""
+    checkify.check(n_samples > 0, "n_samples must be strictly positive.")
+    checkify.check(minimum < maximum, "minimum must be strictly less than maximum.")
+    checkify.check(minimum < peak_maximum, "minimum must be strictly less than peak_maximum.")
+    checkify.check(lambda_peak >= 0.0, "lambda_peak must be non-negative.")
+    checkify.check(lambda_peak <= 1.0, "lambda_peak must be at most 1.")
+    checkify.check(peak_sigma > 0.0, "peak_sigma must be strictly positive.")
+
+    component_key, power_key, peak_key = jax.random.split(key, 3)
+    choose_peak = jax.random.bernoulli(component_key, p=lambda_peak, shape=(n_samples,))
+    power_samples = _sample_power_law(power_key, n_samples=n_samples, alpha=alpha, minimum=minimum, maximum=maximum)
+    peak_samples = _sample_truncated_normal(
+        peak_key,
+        n_samples=n_samples,
+        mean=peak_mean,
+        sigma=peak_sigma,
+        minimum=minimum,
+        maximum=peak_maximum,
+    )
+    return jnp.where(choose_peak, peak_samples, power_samples)
+
+
+def _sample_power_law(key: Array, n_samples: int, alpha: float, minimum: float, maximum: float) -> Array:
+    """Sample a normalized power law on ``[minimum, maximum]`` analytically."""
+    uniform = jax.random.uniform(key, shape=(n_samples,))
+    if jnp.isclose(alpha, 1.0):
+        return minimum * (maximum / minimum) ** uniform
+
+    exponent = 1.0 - alpha
+    lower = minimum**exponent
+    upper = maximum**exponent
+    return (lower + uniform * (upper - lower)) ** (1.0 / exponent)
+
+
+def _sample_truncated_normal(  # noqa: PLR0913
+    key: Array,
+    n_samples: int,
+    mean: float,
+    sigma: float,
+    minimum: float,
+    maximum: float,
+) -> Array:
+    """Sample a truncated normal using JAX's standard-normal helper."""
+    lower = (minimum - mean) / sigma
+    upper = (maximum - mean) / sigma
+    standard_normal = jax.random.truncated_normal(key, lower=lower, upper=upper, shape=(n_samples,))
+    return mean + sigma * standard_normal

--- a/src/gwmock_pop/simulators/bbh/base.py
+++ b/src/gwmock_pop/simulators/bbh/base.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from importlib.resources import as_file, files
+from typing import Any
+
 from gwmock_pop.mixins.random import RandomMixin
+from gwmock_pop.simulators.graph import GraphSimulator
 from gwmock_pop.simulators.simulator import Simulator
 
 
@@ -18,6 +22,31 @@ class BBHSimulator(RandomMixin, Simulator):
             **kwargs: Keyword arguments.
         """
         super().__init__(seed=seed, **kwargs)
+
+    @classmethod
+    def from_preset(cls, preset_name: str, **kwargs: Any) -> Simulator:
+        """Build a graph-backed BBH simulator from a packaged preset config.
+
+        Args:
+            preset_name: Name of the packaged preset.
+            **kwargs: Additional keyword arguments forwarded to ``GraphSimulator``.
+
+        Returns:
+            A graph-backed simulator configured for BBH sampling.
+        """
+        del cls
+
+        preset_map = {
+            "power_law_plus_peak": "bbh_power_law_plus_peak.yaml",
+        }
+        if preset_name not in preset_map:
+            available = ", ".join(sorted(preset_map))
+            raise ValueError(f"Unknown BBH preset {preset_name!r}. Available presets: {available}.")
+
+        options = dict(kwargs)
+        options.setdefault("source_type", "bbh")
+        with as_file(files("gwmock_pop.configs").joinpath(preset_map[preset_name])) as config_path:
+            return GraphSimulator.from_config_file(config_path, **options)
 
     @property
     def parameter_names(self) -> list[str]:

--- a/tests/samplers/test_samplers_mass_ratio_pairing.py
+++ b/tests/samplers/test_samplers_mass_ratio_pairing.py
@@ -1,0 +1,41 @@
+"""Tests for the conditional mass-ratio pairing sampler."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from gwmock_pop.samplers import mass_ratio_pairing
+
+
+def test_mass_ratio_pairing_returns_one_ratio_per_primary_mass() -> None:
+    """Array-valued primary masses produce one conditional ratio each."""
+    primary_mass = jnp.array([10.0, 20.0, 40.0, 80.0])
+
+    mass_ratio = mass_ratio_pairing(
+        key=jax.random.PRNGKey(42),
+        primary_mass=primary_mass,
+        beta=1.26,
+        secondary_minimum=4.59,
+    )
+
+    secondary_mass = primary_mass * mass_ratio
+
+    assert mass_ratio.shape == primary_mass.shape
+    assert bool(jnp.all(mass_ratio <= 1.0))
+    assert bool(jnp.all(secondary_mass >= 4.59))
+
+
+def test_mass_ratio_pairing_supports_scalar_primary_mass_with_n_samples() -> None:
+    """Scalar primary masses can be expanded with ``n_samples``."""
+    mass_ratio = mass_ratio_pairing(
+        key=jax.random.PRNGKey(11),
+        primary_mass=jnp.asarray(30.0),
+        beta=1.26,
+        secondary_minimum=4.59,
+        n_samples=128,
+    )
+
+    assert mass_ratio.shape == (128,)
+    assert bool(jnp.all(mass_ratio >= 4.59 / 30.0))
+    assert bool(jnp.all(mass_ratio <= 1.0))

--- a/tests/samplers/test_samplers_power_law_plus_peak.py
+++ b/tests/samplers/test_samplers_power_law_plus_peak.py
@@ -1,0 +1,46 @@
+"""Tests for the power-law-plus-peak primary-mass sampler."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from gwmock_pop.samplers import power_law_plus_peak
+
+
+def test_power_law_plus_peak_sampler_returns_expected_shape_and_support() -> None:
+    """The sampler returns one primary mass per requested sample within support."""
+    samples = power_law_plus_peak(
+        key=jax.random.PRNGKey(42),
+        n_samples=1_000,
+        alpha=2.63,
+        minimum=4.59,
+        maximum=86.22,
+        lambda_peak=0.10,
+        peak_mean=33.07,
+        peak_sigma=5.69,
+        peak_maximum=100.0,
+    )
+
+    assert samples.shape == (1_000,)
+    assert bool(jnp.all(samples >= 4.59))
+    assert bool(jnp.all(samples <= 100.0))
+
+
+def test_power_law_plus_peak_sampler_is_reproducible_for_fixed_seed() -> None:
+    """The sampler is deterministic for a fixed JAX key."""
+    kwargs = {
+        "n_samples": 256,
+        "alpha": 2.63,
+        "minimum": 4.59,
+        "maximum": 86.22,
+        "lambda_peak": 0.10,
+        "peak_mean": 33.07,
+        "peak_sigma": 5.69,
+        "peak_maximum": 100.0,
+    }
+
+    sample_a = power_law_plus_peak(key=jax.random.PRNGKey(7), **kwargs)
+    sample_b = power_law_plus_peak(key=jax.random.PRNGKey(7), **kwargs)
+
+    assert jnp.allclose(sample_a, sample_b)

--- a/tests/simulators/bbh/test_simulators_bbh_preset.py
+++ b/tests/simulators/bbh/test_simulators_bbh_preset.py
@@ -1,0 +1,75 @@
+"""Tests for packaged BBH preset simulators."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from gwmock_pop.distributions import power_law_plus_peak_cdf
+from gwmock_pop.protocols import GWPopSimulator
+from gwmock_pop.simulators.bbh.base import BBHSimulator
+
+_PRESET_HYPERPARAMETERS = {
+    "alpha": 2.63,
+    "minimum": 4.59,
+    "maximum": 86.22,
+    "lambda_peak": 0.10,
+    "peak_mean": 33.07,
+    "peak_sigma": 5.69,
+    "peak_maximum": 100.0,
+}
+
+
+def _ks_p_value(samples: np.ndarray, cdf: Callable[[np.ndarray], np.ndarray]) -> float:
+    """Return the asymptotic one-sample Kolmogorov-Smirnov p-value."""
+    sample = np.sort(np.asarray(samples, dtype=float))
+    n_samples = sample.size
+    empirical_upper = np.arange(1, n_samples + 1) / n_samples
+    empirical_lower = np.arange(0, n_samples) / n_samples
+    theoretical = np.clip(cdf(sample), 0.0, 1.0)
+    statistic = max(
+        float(np.max(empirical_upper - theoretical)),
+        float(np.max(theoretical - empirical_lower)),
+    )
+    lam = (math.sqrt(n_samples) + 0.12 + 0.11 / math.sqrt(n_samples)) * statistic
+    p_value = 2.0 * sum(((-1) ** (term - 1)) * math.exp(-2.0 * (lam**2) * (term**2)) for term in range(1, 101))
+    return max(0.0, min(1.0, p_value))
+
+
+def test_from_preset_returns_protocol_conformant_simulator() -> None:
+    """The packaged preset builds a graph-backed GWPopSimulator."""
+    simulator = BBHSimulator.from_preset("power_law_plus_peak", seed=42)
+
+    assert isinstance(simulator, GWPopSimulator)
+    assert simulator.source_type == "bbh"
+
+    result = simulator.simulate(128)
+
+    assert list(result.keys()) == list(simulator.parameter_names)
+    assert list(result.keys()) == ["detector_frame_mass_1", "detector_frame_mass_2"]
+    assert all(array.shape == (128,) for array in result.values())
+    assert bool(jnp.all(result["detector_frame_mass_2"] <= result["detector_frame_mass_1"]))
+
+
+def test_from_preset_rejects_unknown_preset_name() -> None:
+    """Unknown preset names raise a helpful error."""
+    with pytest.raises(ValueError, match="Unknown BBH preset"):
+        BBHSimulator.from_preset("does_not_exist")
+
+
+def test_power_law_plus_peak_preset_passes_primary_mass_ks_check() -> None:
+    """The preset's primary-mass samples match the configured reference CDF."""
+    simulator = BBHSimulator.from_preset("power_law_plus_peak", seed=123)
+    result = simulator.simulate(1_000)
+    primary_mass = np.asarray(result["detector_frame_mass_1"])
+
+    p_value = _ks_p_value(
+        primary_mass,
+        lambda x: np.asarray(power_law_plus_peak_cdf(mass=jnp.asarray(x), **_PRESET_HYPERPARAMETERS)),
+    )
+
+    assert p_value > 0.05, p_value


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `power_law_plus_peak` preset configuration for binary black hole population simulations
* Added `BBHSimulator.from_preset()` method enabling easy loading of packaged simulation configurations
* Introduced power-law-plus-peak and mass-ratio pairing distribution models with sampling and probability density functions

## Tests
* Added comprehensive test coverage for new distribution sampling functions and preset-based simulators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->