### PR TITLE
feat: Add comoving volume distance prior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+  "astropy>=7.1.0",
   "bandit[toml]>=1.9.4",
   "hypothesis>=6.152.4",
   "pre-commit>=4.6.0",

--- a/src/gwmock_pop/cosmology/flat_lambda_cdm.py
+++ b/src/gwmock_pop/cosmology/flat_lambda_cdm.py
@@ -8,6 +8,12 @@ from jax import Array
 
 from gwmock_pop.constants import SPEED_OF_LIGHT
 
+PLANCK18_H0_KM_S_MPC = 67.66
+PLANCK18_OMEGA_M = 0.3111
+DEFAULT_MAX_REDSHIFT = 10.0
+DEFAULT_LOOKUP_GRID_SIZE = 4096
+MIN_LOOKUP_GRID_SIZE = 2
+
 
 def compute_normalized_hubble_parameter(redshift: Array, omega_m: Array) -> Array:
     """Compute the normalized Hubble parameter.
@@ -86,3 +92,94 @@ def compute_differential_comoving_volume(
     )
     hubble_parameter = compute_hubble_parameter(redshift=redshift, hubble_constant=hubble_constant, omega_m=omega_m)
     return 4 * jnp.pi * comoving_distance**2 / hubble_parameter * SPEED_OF_LIGHT / 1000
+
+
+def compute_luminosity_distance(redshift: Array, hubble_constant: Array, omega_m: Array, n_grid: int = 1000) -> Array:
+    """Compute the luminosity distance.
+
+    Args:
+        redshift: Redshift to evaluate the luminosity distance.
+        hubble_constant: Hubble constant in km / s / Mpc.
+        omega_m: Matter density.
+        n_grid: Number of grid points to perform the numerical integration.
+
+    Returns:
+        Luminosity distance in Mpc.
+    """
+    return (1.0 + redshift) * compute_comoving_distance(
+        redshift=redshift,
+        hubble_constant=hubble_constant,
+        omega_m=omega_m,
+        n_grid=n_grid,
+    )
+
+
+def build_distance_lookup(
+    *,
+    hubble_constant: float = PLANCK18_H0_KM_S_MPC,
+    omega_m: float = PLANCK18_OMEGA_M,
+    max_redshift: float = DEFAULT_MAX_REDSHIFT,
+    n_grid: int = DEFAULT_LOOKUP_GRID_SIZE,
+) -> tuple[Array, Array, Array]:
+    """Build flat-ΛCDM lookup tables for redshift, comoving distance, and luminosity distance.
+
+    Args:
+        hubble_constant: Hubble constant in km / s / Mpc.
+        omega_m: Matter density.
+        max_redshift: Largest redshift tabulated by the lookup.
+        n_grid: Number of tabulation points.
+
+    Returns:
+        Tuple ``(redshift_grid, comoving_distance_grid, luminosity_distance_grid)``.
+    """
+    if max_redshift <= 0.0:
+        raise ValueError("max_redshift must be positive.")
+    if n_grid < MIN_LOOKUP_GRID_SIZE:
+        raise ValueError(f"n_grid must be at least {MIN_LOOKUP_GRID_SIZE}.")
+
+    redshift_grid = jnp.linspace(0.0, max_redshift, n_grid)
+    inv_e = 1.0 / compute_normalized_hubble_parameter(
+        redshift=redshift_grid,
+        omega_m=jnp.asarray(omega_m),
+    )
+    delta_redshift = jnp.diff(redshift_grid)
+    trapezoids = 0.5 * (inv_e[1:] + inv_e[:-1]) * delta_redshift
+    integral = jnp.concatenate([jnp.zeros(1, dtype=trapezoids.dtype), jnp.cumsum(trapezoids)])
+    comoving_distance_grid = SPEED_OF_LIGHT / 1000 / jnp.asarray(hubble_constant) * integral
+    luminosity_distance_grid = (1.0 + redshift_grid) * comoving_distance_grid
+    return redshift_grid, comoving_distance_grid, luminosity_distance_grid
+
+
+def compute_redshift_from_luminosity_distance(
+    luminosity_distance: Array,
+    *,
+    hubble_constant: float = PLANCK18_H0_KM_S_MPC,
+    omega_m: float = PLANCK18_OMEGA_M,
+    max_redshift: float = DEFAULT_MAX_REDSHIFT,
+    n_grid: int = DEFAULT_LOOKUP_GRID_SIZE,
+) -> Array:
+    """Invert a luminosity distance to redshift via a flat-ΛCDM lookup table.
+
+    Args:
+        luminosity_distance: Luminosity distance in Mpc.
+        hubble_constant: Hubble constant in km / s / Mpc.
+        omega_m: Matter density.
+        max_redshift: Largest redshift tabulated by the lookup.
+        n_grid: Number of tabulation points.
+
+    Returns:
+        Redshift inferred from ``luminosity_distance``.
+    """
+    redshift_grid, _, luminosity_distance_grid = build_distance_lookup(
+        hubble_constant=hubble_constant,
+        omega_m=omega_m,
+        max_redshift=max_redshift,
+        n_grid=n_grid,
+    )
+    return jnp.interp(
+        jnp.asarray(luminosity_distance),
+        luminosity_distance_grid,
+        redshift_grid,
+        left=0.0,
+        right=max_redshift,
+    )

--- a/src/gwmock_pop/samplers/__init__.py
+++ b/src/gwmock_pop/samplers/__init__.py
@@ -8,10 +8,12 @@ from gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks import (
 )
 from gwmock_pop.samplers.planck_tapered_conditional_ratio_power_law import planck_tapered_conditional_ratio_power_law
 from gwmock_pop.samplers.power_law_plus_peak import power_law_plus_peak
+from gwmock_pop.samplers.uniform_comoving_volume_distance import uniform_comoving_volume_distance
 
 __all__ = [
     "mass_ratio_pairing",
     "planck_tapered_broken_power_law_plus_two_peaks",
     "planck_tapered_conditional_ratio_power_law",
     "power_law_plus_peak",
+    "uniform_comoving_volume_distance",
 ]

--- a/src/gwmock_pop/samplers/uniform_comoving_volume_distance.py
+++ b/src/gwmock_pop/samplers/uniform_comoving_volume_distance.py
@@ -1,0 +1,60 @@
+"""Distance samplers for cosmological priors."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+from gwmock_pop.cosmology.flat_lambda_cdm import (
+    DEFAULT_LOOKUP_GRID_SIZE,
+    DEFAULT_MAX_REDSHIFT,
+    PLANCK18_H0_KM_S_MPC,
+    PLANCK18_OMEGA_M,
+    build_distance_lookup,
+)
+
+
+def uniform_comoving_volume_distance(  # noqa: PLR0913
+    key: Array,
+    n_samples: int,
+    d_max: float,
+    *,
+    hubble_constant: float = PLANCK18_H0_KM_S_MPC,
+    omega_m: float = PLANCK18_OMEGA_M,
+    max_redshift: float = DEFAULT_MAX_REDSHIFT,
+    n_grid: int = DEFAULT_LOOKUP_GRID_SIZE,
+) -> Array:
+    """Draw luminosity distances uniformly in comoving volume.
+
+    Args:
+        key: JAX PRNG key.
+        n_samples: Number of distances to sample.
+        d_max: Maximum luminosity distance in Mpc.
+        hubble_constant: Hubble constant in km / s / Mpc.
+        omega_m: Matter density.
+        max_redshift: Largest redshift supported by the lookup table.
+        n_grid: Number of tabulation points.
+
+    Returns:
+        Sampled luminosity distances in Mpc.
+    """
+    if n_samples < 0:
+        raise ValueError(f"n_samples must be >= 0, got {n_samples}.")
+    if d_max <= 0.0:
+        raise ValueError("d_max must be positive.")
+
+    redshift_grid, comoving_distance_grid, luminosity_distance_grid = build_distance_lookup(
+        hubble_constant=hubble_constant,
+        omega_m=omega_m,
+        max_redshift=max_redshift,
+        n_grid=n_grid,
+    )
+    max_supported_distance = float(luminosity_distance_grid[-1])
+    if d_max > max_supported_distance:
+        raise ValueError(f"d_max={d_max} exceeds the luminosity-distance lookup range for max_redshift={max_redshift}.")
+
+    comoving_distance_max = jnp.interp(jnp.asarray(d_max), luminosity_distance_grid, comoving_distance_grid)
+    sampled_comoving_distance = comoving_distance_max * jnp.cbrt(jax.random.uniform(key, shape=(n_samples,)))
+    sampled_redshift = jnp.interp(sampled_comoving_distance, comoving_distance_grid, redshift_grid)
+    return sampled_comoving_distance * (1.0 + sampled_redshift)

--- a/src/gwmock_pop/simulators/cbc_prior.py
+++ b/src/gwmock_pop/simulators/cbc_prior.py
@@ -12,7 +12,7 @@ from jax import Array
 from gwmock_pop.cosmology.flat_lambda_cdm import PLANCK18_H0_KM_S_MPC
 from gwmock_pop.samplers import uniform_comoving_volume_distance
 from gwmock_pop.simulators.bbh.base import BBHSimulator
-from gwmock_pop.transforms import comoving_distance_to_redshift
+from gwmock_pop.transforms import luminosity_distance_to_redshift
 
 _TWO_PI = 2.0 * math.pi
 _SPEED_OF_LIGHT_KM_S = 299792.458
@@ -278,5 +278,5 @@ class CBCPriorSimulator(BBHSimulator):
     def _distance_to_redshift(self, distance: Array) -> Array:
         """Convert luminosity distance to redshift using the configured cosmology mode."""
         if self._accurate_cosmology:
-            return comoving_distance_to_redshift(distance)
+            return luminosity_distance_to_redshift(distance)
         return self._legacy_distance_to_redshift(distance)

--- a/src/gwmock_pop/simulators/cbc_prior.py
+++ b/src/gwmock_pop/simulators/cbc_prior.py
@@ -9,10 +9,12 @@ import jax
 import jax.numpy as jnp
 from jax import Array
 
+from gwmock_pop.cosmology.flat_lambda_cdm import PLANCK18_H0_KM_S_MPC
+from gwmock_pop.samplers import uniform_comoving_volume_distance
 from gwmock_pop.simulators.bbh.base import BBHSimulator
+from gwmock_pop.transforms import comoving_distance_to_redshift
 
 _TWO_PI = 2.0 * math.pi
-_PLANCK18_H0_KM_S_MPC = 67.66
 _SPEED_OF_LIGHT_KM_S = 299792.458
 
 
@@ -21,10 +23,12 @@ class CBCPriorSimulator(BBHSimulator):
 
     The simulator is intentionally independent of the graph engine and provides a
     small configurable prior surface for testing, injection studies, and simple
-    baseline populations. Distances are sampled with a Euclidean
-    ``p(d) proportional to d^2`` approximation on ``[0, d_max]`` and converted to
-    redshift via the low-redshift Hubble-law relation
-    ``z ~= H0 * d / c`` using the Planck18 value ``H0 = 67.66 km s^-1 Mpc^-1``.
+    baseline populations. By default, distances are sampled uniformly in
+    comoving volume and converted to redshift with a flat-ΛCDM lookup using the
+    prompt-specified Planck18 parameters ``H0 = 67.66 km s^-1 Mpc^-1`` and
+    ``Omega_m = 0.3111``. Set ``accurate_cosmology=False`` to recover the legacy
+    Euclidean ``p(d) proportional to d^2`` prior and low-redshift Hubble-law
+    approximation ``z ~= H0 * d / c``.
 
     Component masses are sampled independently and are not reordered after the
     draw. When ``total_mass_max`` is set, the simulator rejects samples with
@@ -45,6 +49,9 @@ class CBCPriorSimulator(BBHSimulator):
         total_mass_max: Optional upper bound on the sum of the two component
             masses.
         f_ref: Constant reference frequency assigned to every sample.
+        accurate_cosmology: If ``True``, sample luminosity distance uniformly in
+            comoving volume and convert it to redshift with the lookup-backed
+            transform. If ``False``, use the legacy low-redshift approximation.
         seed: Optional integer seed forwarded to the parent :class:`BBHSimulator`
             so :class:`~gwmock_pop.mixins.random.RandomMixin` initializes its
             RNG manager for callers that rely on mixin-based randomness.
@@ -63,6 +70,7 @@ class CBCPriorSimulator(BBHSimulator):
         gps_end: float = 1.0,
         total_mass_max: float | None = None,
         f_ref: float = 20.0,
+        accurate_cosmology: bool = True,
         seed: int | None = None,
     ) -> None:
         """Initialize the prior simulator."""
@@ -77,6 +85,7 @@ class CBCPriorSimulator(BBHSimulator):
         self._gps_end = float(gps_end)
         self._total_mass_max = None if total_mass_max is None else float(total_mass_max)
         self._f_ref = float(f_ref)
+        self._accurate_cosmology = accurate_cosmology
         self._validate_configuration()
 
     @property
@@ -216,7 +225,9 @@ class CBCPriorSimulator(BBHSimulator):
         return jnp.concatenate(accepted_mass_1), jnp.concatenate(accepted_mass_2)
 
     def _sample_distance(self, key: Array, n_samples: int) -> Array:
-        """Draw luminosity distance from a Euclidean-volume prior."""
+        """Draw luminosity distance from the configured distance prior."""
+        if self._accurate_cosmology:
+            return uniform_comoving_volume_distance(key=key, n_samples=n_samples, d_max=self._d_max)
         unit_uniform = jax.random.uniform(key, shape=(n_samples,))
         return self._d_max * jnp.cbrt(unit_uniform)
 
@@ -260,6 +271,12 @@ class CBCPriorSimulator(BBHSimulator):
         )
 
     @staticmethod
-    def _distance_to_redshift(distance: Array) -> Array:
+    def _legacy_distance_to_redshift(distance: Array) -> Array:
         """Approximate redshift from luminosity distance using the Hubble law."""
-        return distance * (_PLANCK18_H0_KM_S_MPC / _SPEED_OF_LIGHT_KM_S)
+        return distance * (PLANCK18_H0_KM_S_MPC / _SPEED_OF_LIGHT_KM_S)
+
+    def _distance_to_redshift(self, distance: Array) -> Array:
+        """Convert luminosity distance to redshift using the configured cosmology mode."""
+        if self._accurate_cosmology:
+            return comoving_distance_to_redshift(distance)
+        return self._legacy_distance_to_redshift(distance)

--- a/src/gwmock_pop/transforms/__init__.py
+++ b/src/gwmock_pop/transforms/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from gwmock_pop.transforms.basic import constant_like, multiply
+from gwmock_pop.transforms.basic import comoving_distance_to_redshift, constant_like, multiply
 
-__all__ = ["constant_like", "multiply"]
+__all__ = ["comoving_distance_to_redshift", "constant_like", "multiply"]

--- a/src/gwmock_pop/transforms/__init__.py
+++ b/src/gwmock_pop/transforms/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
-from gwmock_pop.transforms.basic import comoving_distance_to_redshift, constant_like, multiply
+from gwmock_pop.transforms.basic import (
+    constant_like,
+    luminosity_distance_to_redshift,
+    multiply,
+)
 
-__all__ = ["comoving_distance_to_redshift", "constant_like", "multiply"]
+__all__ = [
+    "constant_like",
+    "luminosity_distance_to_redshift",
+    "multiply",
+]

--- a/src/gwmock_pop/transforms/basic.py
+++ b/src/gwmock_pop/transforms/basic.py
@@ -41,8 +41,8 @@ def multiply(left: Array, right: Array) -> Array:
     return jnp.asarray(left) * jnp.asarray(right)
 
 
-def comoving_distance_to_redshift(
-    distance: Array,
+def luminosity_distance_to_redshift(
+    luminosity_distance: Array,
     *,
     hubble_constant: float = PLANCK18_H0_KM_S_MPC,
     omega_m: float = PLANCK18_OMEGA_M,
@@ -51,21 +51,18 @@ def comoving_distance_to_redshift(
 ) -> Array:
     """Convert luminosity distance to redshift with a flat-ΛCDM lookup.
 
-    The historical transform name is retained for graph-config compatibility even
-    though the input quantity is luminosity distance.
-
     Args:
-        distance: Luminosity distance in Mpc.
+        luminosity_distance: Luminosity distance in Mpc.
         hubble_constant: Hubble constant in km / s / Mpc.
         omega_m: Matter density.
         max_redshift: Largest redshift supported by the lookup table.
         n_grid: Number of tabulation points.
 
     Returns:
-        Redshift inferred from ``distance``.
+        Redshift inferred from ``luminosity_distance``.
     """
     return compute_redshift_from_luminosity_distance(
-        luminosity_distance=distance,
+        luminosity_distance=luminosity_distance,
         hubble_constant=hubble_constant,
         omega_m=omega_m,
         max_redshift=max_redshift,

--- a/src/gwmock_pop/transforms/basic.py
+++ b/src/gwmock_pop/transforms/basic.py
@@ -5,6 +5,14 @@ from __future__ import annotations
 import jax.numpy as jnp
 from jax import Array
 
+from gwmock_pop.cosmology.flat_lambda_cdm import (
+    DEFAULT_LOOKUP_GRID_SIZE,
+    DEFAULT_MAX_REDSHIFT,
+    PLANCK18_H0_KM_S_MPC,
+    PLANCK18_OMEGA_M,
+    compute_redshift_from_luminosity_distance,
+)
+
 
 def constant_like(reference: Array, value: float) -> Array:
     """Return a constant array with the same shape as ``reference``.
@@ -31,3 +39,35 @@ def multiply(left: Array, right: Array) -> Array:
         Elementwise product of ``left`` and ``right``.
     """
     return jnp.asarray(left) * jnp.asarray(right)
+
+
+def comoving_distance_to_redshift(
+    distance: Array,
+    *,
+    hubble_constant: float = PLANCK18_H0_KM_S_MPC,
+    omega_m: float = PLANCK18_OMEGA_M,
+    max_redshift: float = DEFAULT_MAX_REDSHIFT,
+    n_grid: int = DEFAULT_LOOKUP_GRID_SIZE,
+) -> Array:
+    """Convert luminosity distance to redshift with a flat-ΛCDM lookup.
+
+    The historical transform name is retained for graph-config compatibility even
+    though the input quantity is luminosity distance.
+
+    Args:
+        distance: Luminosity distance in Mpc.
+        hubble_constant: Hubble constant in km / s / Mpc.
+        omega_m: Matter density.
+        max_redshift: Largest redshift supported by the lookup table.
+        n_grid: Number of tabulation points.
+
+    Returns:
+        Redshift inferred from ``distance``.
+    """
+    return compute_redshift_from_luminosity_distance(
+        luminosity_distance=distance,
+        hubble_constant=hubble_constant,
+        omega_m=omega_m,
+        max_redshift=max_redshift,
+        n_grid=n_grid,
+    )

--- a/tests/cosmology/test_cosmology_flat_lambda_cdm.py
+++ b/tests/cosmology/test_cosmology_flat_lambda_cdm.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
+from astropy import units as u
+from astropy.cosmology import FlatLambdaCDM, z_at_value
 from jax import Array
 
 from gwmock_pop.constants import SPEED_OF_LIGHT
 from gwmock_pop.cosmology.flat_lambda_cdm import (
+    PLANCK18_H0_KM_S_MPC,
+    PLANCK18_OMEGA_M,
+    build_distance_lookup,
     compute_comoving_distance,
     compute_differential_comoving_volume,
     compute_hubble_parameter,
+    compute_luminosity_distance,
     compute_normalized_hubble_parameter,
+    compute_redshift_from_luminosity_distance,
 )
+
+_REFERENCE_COSMOLOGY = FlatLambdaCDM(H0=PLANCK18_H0_KM_S_MPC, Om0=PLANCK18_OMEGA_M)
 
 
 class TestFlatLambdaCDM:
@@ -171,3 +180,59 @@ class TestFlatLambdaCDM:
         )
 
         assert isinstance(result, Array)
+
+    def test_compute_luminosity_distance(self) -> None:
+        """Luminosity distance is ``(1 + z)`` times the comoving distance."""
+        redshift = jnp.array(1.0)
+        hubble_constant = jnp.array(70.0)
+        omega_m = jnp.array(0.3)
+
+        luminosity_distance = compute_luminosity_distance(
+            redshift=redshift,
+            hubble_constant=hubble_constant,
+            omega_m=omega_m,
+            n_grid=1000,
+        )
+        comoving_distance = compute_comoving_distance(
+            redshift=redshift,
+            hubble_constant=hubble_constant,
+            omega_m=omega_m,
+            n_grid=1000,
+        )
+
+        assert jnp.isclose(luminosity_distance, (1.0 + redshift) * comoving_distance)
+
+    def test_build_distance_lookup_starts_at_zero_and_increases_monotonically(self) -> None:
+        """The lookup table should span physical, monotonically increasing distances."""
+        redshift_grid, comoving_distance_grid, luminosity_distance_grid = build_distance_lookup()
+
+        assert redshift_grid.shape == comoving_distance_grid.shape == luminosity_distance_grid.shape
+        assert redshift_grid[0] == 0.0
+        assert comoving_distance_grid[0] == 0.0
+        assert luminosity_distance_grid[0] == 0.0
+        assert jnp.all(jnp.diff(redshift_grid) > 0.0)
+        assert jnp.all(jnp.diff(comoving_distance_grid) >= 0.0)
+        assert jnp.all(jnp.diff(luminosity_distance_grid) >= 0.0)
+
+    @staticmethod
+    def _luminosity_distance_at_redshift(redshift: float) -> float:
+        """Return the Astropy luminosity distance for the reference cosmology."""
+        return float(_REFERENCE_COSMOLOGY.luminosity_distance(redshift).to_value(u.Mpc))
+
+    @staticmethod
+    def _astropy_redshift_from_distance(distance_mpc: float) -> float:
+        """Return the Astropy redshift for a luminosity distance."""
+        return float(z_at_value(_REFERENCE_COSMOLOGY.luminosity_distance, distance_mpc * u.Mpc))
+
+    @staticmethod
+    def _relative_error(measured: float, expected: float) -> float:
+        """Return the relative error against a non-zero reference."""
+        return abs(measured - expected) / expected
+
+    def test_compute_redshift_from_luminosity_distance_matches_astropy_reference(self) -> None:
+        """The lookup-based inversion matches the Astropy cosmology reference."""
+        for expected_redshift in (0.01, 0.1, 1.0, 5.0, 10.0):
+            luminosity_distance = self._luminosity_distance_at_redshift(expected_redshift)
+            measured_redshift = float(compute_redshift_from_luminosity_distance(jnp.array(luminosity_distance)))
+            reference_redshift = self._astropy_redshift_from_distance(luminosity_distance)
+            assert self._relative_error(measured_redshift, reference_redshift) < 1e-3

--- a/tests/samplers/test_samplers_uniform_comoving_volume_distance.py
+++ b/tests/samplers/test_samplers_uniform_comoving_volume_distance.py
@@ -1,0 +1,54 @@
+"""Tests for the cosmological distance sampler."""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import numpy as np
+import pytest
+
+from gwmock_pop.samplers import uniform_comoving_volume_distance
+from gwmock_pop.transforms import comoving_distance_to_redshift
+
+
+def _ks_p_value(samples: np.ndarray, cdf) -> float:
+    """Return the asymptotic one-sample Kolmogorov-Smirnov p-value."""
+    sample = np.sort(np.asarray(samples, dtype=float))
+    n_samples = sample.size
+    empirical_upper = np.arange(1, n_samples + 1) / n_samples
+    empirical_lower = np.arange(0, n_samples) / n_samples
+    theoretical = np.clip(cdf(sample), 0.0, 1.0)
+    statistic = max(
+        float(np.max(empirical_upper - theoretical)),
+        float(np.max(theoretical - empirical_lower)),
+    )
+    lam = (math.sqrt(n_samples) + 0.12 + 0.11 / math.sqrt(n_samples)) * statistic
+    p_value = 2.0 * sum(((-1) ** (term - 1)) * math.exp(-2.0 * (lam**2) * (term**2)) for term in range(1, 101))
+    return max(0.0, min(1.0, p_value))
+
+
+def test_uniform_comoving_volume_distance_draws_within_requested_range() -> None:
+    """The sampler returns luminosity distances in ``[0, d_max]``."""
+    result = uniform_comoving_volume_distance(jax.random.PRNGKey(0), 1024, 40_000.0)
+    assert result.shape == (1024,)
+    assert np.all(np.asarray(result) >= 0.0)
+    assert np.all(np.asarray(result) <= 40_000.0)
+
+
+def test_uniform_comoving_volume_distance_is_uniform_in_comoving_volume() -> None:
+    """The implied comoving-distance CDF follows ``(d_c / d_c,max)^3``."""
+    d_max = 40_000.0
+    distance = uniform_comoving_volume_distance(jax.random.PRNGKey(123), 10_000, d_max)
+    redshift = comoving_distance_to_redshift(distance)
+    comoving_distance = np.asarray(distance) / (1.0 + np.asarray(redshift))
+    comoving_distance_max = d_max / (1.0 + float(comoving_distance_to_redshift(np.asarray(d_max))))
+
+    p_value = _ks_p_value(comoving_distance, lambda x: np.clip((x / comoving_distance_max) ** 3, 0.0, 1.0))
+    assert p_value > 0.01, p_value
+
+
+def test_uniform_comoving_volume_distance_rejects_out_of_lookup_range() -> None:
+    """The sampler raises when ``d_max`` exceeds the configured lookup support."""
+    with pytest.raises(ValueError, match="exceeds the luminosity-distance lookup range"):
+        uniform_comoving_volume_distance(jax.random.PRNGKey(0), 16, 200_000.0)

--- a/tests/samplers/test_samplers_uniform_comoving_volume_distance.py
+++ b/tests/samplers/test_samplers_uniform_comoving_volume_distance.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from gwmock_pop.samplers import uniform_comoving_volume_distance
-from gwmock_pop.transforms import comoving_distance_to_redshift
+from gwmock_pop.transforms import luminosity_distance_to_redshift
 
 
 def _ks_p_value(samples: np.ndarray, cdf) -> float:
@@ -40,9 +40,9 @@ def test_uniform_comoving_volume_distance_is_uniform_in_comoving_volume() -> Non
     """The implied comoving-distance CDF follows ``(d_c / d_c,max)^3``."""
     d_max = 40_000.0
     distance = uniform_comoving_volume_distance(jax.random.PRNGKey(123), 10_000, d_max)
-    redshift = comoving_distance_to_redshift(distance)
+    redshift = luminosity_distance_to_redshift(distance)
     comoving_distance = np.asarray(distance) / (1.0 + np.asarray(redshift))
-    comoving_distance_max = d_max / (1.0 + float(comoving_distance_to_redshift(np.asarray(d_max))))
+    comoving_distance_max = d_max / (1.0 + float(luminosity_distance_to_redshift(np.asarray(d_max))))
 
     p_value = _ks_p_value(comoving_distance, lambda x: np.clip((x / comoving_distance_max) ** 3, 0.0, 1.0))
     assert p_value > 0.01, p_value

--- a/tests/simulators/test_cbc_prior.py
+++ b/tests/simulators/test_cbc_prior.py
@@ -119,7 +119,7 @@ def test_legacy_cosmology_mode_reproduces_low_redshift_hubble_law() -> None:
         cbc_prior_module.PLANCK18_H0_KM_S_MPC / cbc_prior_module._SPEED_OF_LIGHT_KM_S
     )
 
-    np.testing.assert_allclose(np.asarray(result["redshift"]), expected_redshift)
+    np.testing.assert_allclose(np.asarray(result["redshift"]), expected_redshift, rtol=1e-5)
 
 
 def test_aligned_spins_zero_in_plane_components() -> None:

--- a/tests/simulators/test_cbc_prior.py
+++ b/tests/simulators/test_cbc_prior.py
@@ -9,11 +9,13 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from gwmock_pop import CBCPriorSimulator
 from gwmock_pop.protocols import GWPopSimulator
+from gwmock_pop.simulators import cbc_prior as cbc_prior_module
 
 
 def _ks_p_value(samples: np.ndarray, cdf: Callable[[np.ndarray], np.ndarray]) -> float:
@@ -66,7 +68,7 @@ def test_constructor_forwards_seed_to_random_mixin() -> None:
 
 def test_requested_marginals_pass_ks_checks() -> None:
     """The requested RA, declination, distance, and mass marginals match their targets."""
-    simulator = CBCPriorSimulator(m_min=10.0, m_max=80.0, d_max=2_000.0)
+    simulator = CBCPriorSimulator(m_min=10.0, m_max=80.0, d_max=2_000.0, accurate_cosmology=False)
     result = simulator.simulate(10_000, seed=123)
 
     right_ascension = np.asarray(result["right_ascension"])
@@ -83,6 +85,41 @@ def test_requested_marginals_pass_ks_checks() -> None:
     assert p_declination > 0.01, p_declination
     assert p_distance > 0.01, p_distance
     assert p_mass_1 > 0.01, p_mass_1
+
+
+def test_accurate_cosmology_mode_uses_lookup_sampler_and_transform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Accurate cosmology mode delegates to the new sampler and transform nodes."""
+    calls = {"sampler": 0, "transform": 0}
+
+    def fake_sampler(*, key, n_samples: int, d_max: float):
+        calls["sampler"] += 1
+        assert d_max == 5_000.0
+        return jnp.full((n_samples,), 1234.5)
+
+    def fake_transform(distance):
+        calls["transform"] += 1
+        return jnp.full(distance.shape, 0.321)
+
+    monkeypatch.setattr(cbc_prior_module, "uniform_comoving_volume_distance", fake_sampler)
+    monkeypatch.setattr(cbc_prior_module, "comoving_distance_to_redshift", fake_transform)
+
+    result = CBCPriorSimulator().simulate(8, seed=7)
+
+    assert calls == {"sampler": 1, "transform": 1}
+    np.testing.assert_array_equal(np.asarray(result["distance"]), np.full(8, 1234.5))
+    np.testing.assert_allclose(np.asarray(result["redshift"]), np.full(8, 0.321))
+
+
+def test_legacy_cosmology_mode_reproduces_low_redshift_hubble_law() -> None:
+    """Legacy cosmology mode preserves the previous low-redshift approximation."""
+    simulator = CBCPriorSimulator(d_max=2_000.0, accurate_cosmology=False)
+
+    result = simulator.simulate(4096, seed=42)
+    expected_redshift = np.asarray(result["distance"]) * (
+        cbc_prior_module.PLANCK18_H0_KM_S_MPC / cbc_prior_module._SPEED_OF_LIGHT_KM_S
+    )
+
+    np.testing.assert_allclose(np.asarray(result["redshift"]), expected_redshift)
 
 
 def test_aligned_spins_zero_in_plane_components() -> None:

--- a/tests/simulators/test_cbc_prior.py
+++ b/tests/simulators/test_cbc_prior.py
@@ -101,7 +101,7 @@ def test_accurate_cosmology_mode_uses_lookup_sampler_and_transform(monkeypatch: 
         return jnp.full(distance.shape, 0.321)
 
     monkeypatch.setattr(cbc_prior_module, "uniform_comoving_volume_distance", fake_sampler)
-    monkeypatch.setattr(cbc_prior_module, "comoving_distance_to_redshift", fake_transform)
+    monkeypatch.setattr(cbc_prior_module, "luminosity_distance_to_redshift", fake_transform)
 
     result = CBCPriorSimulator().simulate(8, seed=7)
 

--- a/uv.lock
+++ b/uv.lock
@@ -38,6 +38,38 @@ wheels = [
 ]
 
 [[package]]
+name = "astropy"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astropy-iers-data" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyerfa" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/92/2dce2d48347efc3346d08ca7995b152d242ebd170c571f7c9346468d8427/astropy-7.2.0.tar.gz", hash = "sha256:ae48bc26b1feaeb603cd94bd1fa1aa39137a115fe931b7f13787ab420e8c3070", size = 7057774, upload-time = "2025-11-25T22:36:41.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/6d/6330a844bad8dfc4875e0f2fa1db1fee87837ba9805aa8a8d048c071363a/astropy-7.2.0-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:efac04df4cc488efe630c2fff1992d6516dfb16a06e197fb68bc9e8e3b85def1", size = 6442332, upload-time = "2025-11-25T22:36:23.6Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ba/3418133ba144dfcd1530bca5a6b695f4cdd21a8abaaa2ac4e5450d11b028/astropy-7.2.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:52e9a7d9c86b21f1af911a2930cd0c4a275fb302d455c89e11eedaffef6f2ad0", size = 6413656, upload-time = "2025-11-25T22:36:26.548Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ba/05e43b5a7d738316a097fa78524d3eaaff5986294b4a052d4adb3c45e7c0/astropy-7.2.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97c370421b9bb13d4c762c7af06d172bad7c01bd5bcf88314f6913c3c235b770", size = 9758867, upload-time = "2025-11-25T22:36:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/f06ad85180e7dd9855aa5ede901bfc2be858d7bee17d4e978a14c0ecec14/astropy-7.2.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f39ce2c80211fbceb005d377a5478cd0d66c42aa1498d252f2239fe5a025c24", size = 9789007, upload-time = "2025-11-25T22:36:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fb/e4d35194a5009d7a73333079481a4ef1380a255d67b9c1db578151a5fb50/astropy-7.2.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ad4d71db994d45f046a1a5449000cf0f88ab6367cb67658500654a0586d6ab19", size = 9748547, upload-time = "2025-11-25T22:36:33.154Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ea/f990730978ae0a7a34705f885d2f3806928c5f0bc22eefd6a1a23539cc32/astropy-7.2.0-cp311-abi3-win32.whl", hash = "sha256:95161f26602433176483e8bde8ab1a8ca09148f5b4bf5190569a26d381091598", size = 6237228, upload-time = "2025-11-25T22:36:35.236Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bc/f4378f586dd63902c37d16f68f35f7d555b3b32e08ac6b1d633eb0a48805/astropy-7.2.0-cp311-abi3-win_amd64.whl", hash = "sha256:dc7c340ba1713e55c93071b32033f3153470a0f663a4d539c03a7c9b44020790", size = 6362868, upload-time = "2025-11-25T22:36:37.784Z" },
+    { url = "https://files.pythonhosted.org/packages/77/79/b6d4bf01913cfd4ce0cd4c1be5916beccdb92b2970bab8c827984231eae6/astropy-7.2.0-cp311-abi3-win_arm64.whl", hash = "sha256:0c428735a3f15b05c2095bc6ccb5f98a64bc99fb7015866af19ff8492420ddaf", size = 6221756, upload-time = "2025-11-25T22:36:39.852Z" },
+]
+
+[[package]]
+name = "astropy-iers-data"
+version = "0.2026.4.27.1.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/e5/dc5474840c8b4ccf73db3475f88d9e40fcffa728f23e87707afa3460b30c/astropy_iers_data-0.2026.4.27.1.3.2.tar.gz", hash = "sha256:fc71b5b2e601afb1b8c4f22a35161c551d67469ec65502123591dae6a87d453b", size = 1931758, upload-time = "2026-04-27T01:03:45.375Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/14/1c50311a2873e8c89f0b1d0eda65cf572b360917b14b70ba9d0678fc6acc/astropy_iers_data-0.2026.4.27.1.3.2-py3-none-any.whl", hash = "sha256:3c09006b1b7c369a4dd9ba7e395b04cbfedb41a9253013b3bf7e5b8ac53a7699", size = 1988568, upload-time = "2026-04-27T01:03:43.278Z" },
+]
+
+[[package]]
 name = "backports-zstd"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -410,6 +442,7 @@ build = [
     { name = "hatch" },
 ]
 dev = [
+    { name = "astropy" },
     { name = "bandit" },
     { name = "hypothesis" },
     { name = "pre-commit" },
@@ -440,6 +473,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 build = [{ name = "hatch", specifier = ">=1.16.5" }]
 dev = [
+    { name = "astropy", specifier = ">=7.1.0" },
     { name = "bandit", extras = ["toml"], specifier = ">=1.9.4" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "pre-commit", specifier = ">=4.6.0" },
@@ -1234,6 +1268,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
     { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
     { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pyerfa"
+version = "2.0.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/39/63cc8291b0cf324ae710df41527faf7d331bce573899199d926b3e492260/pyerfa-2.0.1.5.tar.gz", hash = "sha256:17d6b24fe4846c65d5e7d8c362dcb08199dc63b30a236aedd73875cc83e1f6c0", size = 818430, upload-time = "2024-11-11T15:22:30.852Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d9/3448a57cb5bd19950de6d6ab08bd8fbb3df60baa71726de91d73d76c481b/pyerfa-2.0.1.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b282d7c60c4c47cf629c484c17ac504fcb04abd7b3f4dfcf53ee042afc3a5944", size = 341818, upload-time = "2024-11-11T15:22:16.467Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4a/31a363370478b63c6289a34743f2ba2d3ae1bd8223e004d18ab28fb92385/pyerfa-2.0.1.5-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:be1aeb70390dd03a34faf96749d5cabc58437410b4aab7213c512323932427df", size = 329370, upload-time = "2024-11-11T15:22:17.829Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/96/b6210fc624123c8ae13e1eecb68fb75e3f3adff216d95eee1c7b05843e3e/pyerfa-2.0.1.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b0603e8e1b839327d586c8a627cdc634b795e18b007d84f0cda5500a0908254e", size = 692794, upload-time = "2024-11-11T15:22:19.429Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e0/050018d855d26d3c0b4a7d1b2ed692be758ce276d8289e2a2b44ba1014a5/pyerfa-2.0.1.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e43c7194e3242083f2350b46c09fd4bf8ba1bcc0ebd1460b98fc47fe2389906", size = 738711, upload-time = "2024-11-11T15:22:20.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f5/ff91ee77308793ae32fa1e1de95e9edd4551456dd888b4e87c5938657ca5/pyerfa-2.0.1.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:07b80cd70701f5d066b1ac8cce406682cfcd667a1186ec7d7ade597239a6021d", size = 722966, upload-time = "2024-11-11T15:22:21.905Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/56/b22b35c8551d2228ff8d445e63787112927ca13f6dc9e2c04f69d742c95b/pyerfa-2.0.1.5-cp39-abi3-win32.whl", hash = "sha256:d30b9b0df588ed5467e529d851ea324a67239096dd44703125072fd11b351ea2", size = 339955, upload-time = "2024-11-11T15:22:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/11/97233cf23ad5411ac6f13b1d6ee3888f90ace4f974d9bf9db887aa428912/pyerfa-2.0.1.5-cp39-abi3-win_amd64.whl", hash = "sha256:66292d437dcf75925b694977aa06eb697126e7b86553e620371ed3e48b5e0ad0", size = 349410, upload-time = "2024-11-11T15:22:24.817Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accurate cosmology support to CBC prior simulator with configurable modes
  * Introduced uniform comoving volume distance sampler for realistic gravitational wave population distributions
  * Added luminosity distance-to-redshift transform using Planck18 cosmological parameters

* **Dependencies**
  * Added astropy as a development dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->