### PR TITLE
feat: Add Add a gwmock-pop simulate CLI subcommand that samples N events from a named preset or config file and writes output to HDF5 or CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gwmock-pop
 
-[![Python CI](https://github.com/Leuven-Gravity-Institute/gwmock-pop/actions/workflows/CI.yml/badge.svg)](https://github.com/Leuven-Gravity-Institute/gwmock-pop/actions/workflows/CI.yml)
+[![Python CI](https://github.com/Leuven-Gravity-Institute/gwmock-pop/actions/workflows/ci.yml/badge.svg)](https://github.com/Leuven-Gravity-Institute/gwmock-pop/actions/workflows/ci.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Leuven-Gravity-Institute/gwmock-pop/main.svg)](https://results.pre-commit.ci/latest/github/Leuven-Gravity-Institute/gwmock-pop/main)
 [![Documentation Status](https://github.com/Leuven-Gravity-Institute/gwmock-pop/actions/workflows/documentation.yml/badge.svg)](https://leuven-gravity-institute.github.io/gwmock-pop/)
 [![codecov](https://codecov.io/gh/leuven-gravity-institute/gwmock-pop/graph/badge.svg?token=Vwf7NYTHCm)](https://codecov.io/gh/leuven-gravity-institute/gwmock-pop)

--- a/src/gwmock_pop/cli/simulate.py
+++ b/src/gwmock_pop/cli/simulate.py
@@ -1,82 +1,139 @@
-"""Simulate populations."""
+"""Simulate populations from packaged presets or graph config files."""
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
+import h5py
+import numpy as np
 import typer
-from pydantic import ValidationError
+from jax import Array
 
-from gwmock_pop.config.main import MainConfiguration
+from gwmock_pop.protocols import GWPopSimulator
+from gwmock_pop.simulators.bbh.base import BBHSimulator
 from gwmock_pop.simulators.graph import GraphSimulator
 
-
-def _get_output_path(config: MainConfiguration) -> Path:
-    """Build the output path for a simulation run."""
-    output_dir = Path(config.run.output.directory)
-    suffixes = {"csv": ".csv", "hdf5": ".hdf5", "npz": ".npz"}
-    return output_dir / f"{config.run.name}{suffixes[config.run.output.format]}"
+_HDF5_DATASET_NAME = "data"
+_SUPPORTED_OUTPUT_SUFFIXES = {".csv": "csv", ".hdf5": "hdf5", ".h5": "hdf5"}
+_CONFIG_FILE_SUFFIXES = {".yaml", ".yml", ".toml"}
 
 
-def _build_output_metadata(config: MainConfiguration, simulator: GraphSimulator) -> dict[str, Any]:
-    """Build generic output metadata for formats that can persist it."""
-    return {
-        "config_version": config.config_version,
-        "run_name": config.run.name,
-        "n_samples": config.run.n_samples,
-        "seed": config.run.seed,
-        "parameter_names": simulator.parameter_names,
-    }
+def _infer_output_format(output_path: Path) -> str:
+    """Infer the persistence format from the output file suffix."""
+    file_format = _SUPPORTED_OUTPUT_SUFFIXES.get(output_path.suffix.lower())
+    if file_format is None:
+        supported = ", ".join(sorted(_SUPPORTED_OUTPUT_SUFFIXES))
+        raise ValueError(f"Unsupported output format for {output_path}. Supported suffixes: {supported}.")
+    return file_format
 
 
-def simulate_command(filename: Annotated[str, typer.Argument(help="File name of the configuration file.")]) -> None:
-    """Simulate a population from a configuration file.
+def _resolve_simulator(config: str, seed: int | None) -> GWPopSimulator:
+    """Build a simulator from either a packaged preset name or a config-file path."""
+    config_path = Path(config).expanduser()
+    if config_path.exists():
+        return GraphSimulator.from_config_file(config_path, source_type="bbh", seed=seed)
 
-    Args:
-        filename: File name of the configuration file.
-    """
+    try:
+        return BBHSimulator.from_preset(config, seed=seed)
+    except ValueError as error:
+        if config_path.suffix.lower() in _CONFIG_FILE_SUFFIXES:
+            raise FileNotFoundError(f"Configuration file does not exist: {config_path}") from error
+        raise ValueError(f"Unknown preset or configuration path {config!r}.") from error
+
+
+def _population_columns(population: Mapping[str, Array]) -> list[str]:
+    """Return the stable output column ordering for a sampled population."""
+    return list(population)
+
+
+def _population_size(population: Mapping[str, Array], columns: Sequence[str]) -> int:
+    """Return the number of sampled rows in the population."""
+    if not columns:
+        return 0
+    return int(np.asarray(population[columns[0]]).shape[0])
+
+
+def _population_matrix(population: Mapping[str, Array], columns: Sequence[str], n_rows: int) -> np.ndarray:
+    """Materialize the sampled population as a dense 2-D matrix."""
+    matrix = np.empty((n_rows, len(columns)), dtype=float)
+    for column_index, column_name in enumerate(columns):
+        matrix[:, column_index] = np.asarray(population[column_name], dtype=float)
+    return matrix
+
+
+def _population_structured_array(population: Mapping[str, Array], columns: Sequence[str], n_rows: int) -> np.ndarray:
+    """Materialize the sampled population as a structured array with named columns."""
+    dtype = [(column_name, np.asarray(population[column_name]).dtype) for column_name in columns]
+    structured = np.empty(n_rows, dtype=dtype)
+    for column_name in columns:
+        structured[column_name] = np.asarray(population[column_name])
+    return structured
+
+
+def _write_population_csv(
+    output_path: Path, population: Mapping[str, Array], columns: Sequence[str], n_rows: int
+) -> None:
+    """Persist a population as a header-based CSV file."""
+    matrix = _population_matrix(population=population, columns=columns, n_rows=n_rows)
+    np.savetxt(output_path, matrix, delimiter=",", header=",".join(columns), comments="")
+
+
+def _write_population_hdf5(
+    output_path: Path, population: Mapping[str, Array], columns: Sequence[str], n_rows: int
+) -> None:
+    """Persist a population as a structured HDF5 dataset named ``data``."""
+    structured = _population_structured_array(population=population, columns=columns, n_rows=n_rows)
+    with h5py.File(output_path, "w") as handle:
+        handle.create_dataset(_HDF5_DATASET_NAME, data=structured)
+
+
+def _write_population(output_path: Path, population: Mapping[str, Array]) -> None:
+    """Persist a sampled population using named-column conventions."""
+    columns = _population_columns(population)
+    n_rows = _population_size(population=population, columns=columns)
+    file_format = _infer_output_format(output_path)
+
+    if file_format == "csv":
+        _write_population_csv(output_path=output_path, population=population, columns=columns, n_rows=n_rows)
+        return
+    if file_format == "hdf5":
+        _write_population_hdf5(output_path=output_path, population=population, columns=columns, n_rows=n_rows)
+        return
+
+    raise ValueError(f"Unsupported output format {file_format!r}.")
+
+
+def simulate_command(
+    config: Annotated[str, typer.Option("--config", help="Preset name or YAML/TOML config-file path.")],
+    n: Annotated[int, typer.Option("--n", min=0, help="Number of events to sample.")],
+    output: Annotated[Path, typer.Option("--output", help="Destination .csv, .h5, or .hdf5 file.")],
+    seed: Annotated[int | None, typer.Option("--seed", help="Optional random seed.")] = None,
+) -> None:
+    """Simulate a population and persist it as a named-column catalogue."""
     import logging  # noqa: PLC0415
 
     logger = logging.getLogger("gwmock_pop")
 
     try:
-        config = MainConfiguration.from_file(filename)
-    except (FileNotFoundError, ValidationError, ValueError) as error:
-        logger.error("Failed to load configuration from %s: %s", filename, error)
+        simulator = _resolve_simulator(config=config, seed=seed)
+        output_path = output.expanduser()
+        _infer_output_format(output_path)
+    except (FileNotFoundError, ValueError) as error:
+        logger.error("%s", error)
         raise typer.Exit(1) from error
 
-    if config.run.mode != "fixed_n_samples":
-        logger.error("Only run.mode='fixed_n_samples' is supported by the CLI MVP.")
-        raise typer.Exit(1)
-
-    if not config.parameters:
-        logger.error("No parameter graph configuration found under 'parameters'.")
-        raise typer.Exit(1)
-
-    output_path = _get_output_path(config)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if output_path.exists() and not config.run.output.overwrite:
-        logger.error(
-            "Refusing to overwrite existing output file %s. Set run.output.overwrite=true to replace it.",
-            output_path,
-        )
+    if output_path.exists():
+        logger.error("Refusing to overwrite existing output file %s.", output_path)
         raise typer.Exit(1)
 
-    simulator = GraphSimulator(config=config.parameters, seed=config.run.seed, source_type="population")
-    population = simulator.simulate(n_samples=config.run.n_samples)
+    try:
+        population = simulator.simulate(n)
+        _write_population(output_path=output_path, population=population)
+    except ValueError as error:
+        logger.error("%s", error)
+        raise typer.Exit(1) from error
 
-    metadata = None
-    if config.run.output.save_metadata:
-        metadata = _build_output_metadata(config, simulator)
-
-    simulator.save(
-        output_path=output_path,
-        file_format=config.run.output.format,
-        data=population,
-        compression=config.run.output.compression,
-        metadata=metadata,
-    )
-    sample_count = len(next(iter(population.values()))) if population else 0
-    logger.info("Saved %s samples to %s", sample_count, output_path)
+    logger.info("Saved %s samples to %s", n, output_path)

--- a/src/gwmock_pop/cli/simulate.py
+++ b/src/gwmock_pop/cli/simulate.py
@@ -120,7 +120,7 @@ def simulate_command(
         simulator = _resolve_simulator(config=config, seed=seed)
         output_path = output.expanduser()
         _infer_output_format(output_path)
-    except (FileNotFoundError, ValueError) as error:
+    except Exception as error:
         logger.error("%s", error)
         raise typer.Exit(1) from error
 
@@ -132,7 +132,7 @@ def simulate_command(
     try:
         population = simulator.simulate(n)
         _write_population(output_path=output_path, population=population)
-    except ValueError as error:
+    except Exception as error:
         logger.error("%s", error)
         raise typer.Exit(1) from error
 

--- a/src/gwmock_pop/configs/bbh_gwtc4.yaml
+++ b/src/gwmock_pop/configs/bbh_gwtc4.yaml
@@ -1,0 +1,183 @@
+parameters:
+    detector_frame_mass_1:
+        sampler:
+            function: planck_tapered_broken_power_law_plus_two_peaks
+            arguments:
+                alpha_1: 1.72
+                alpha_2: 4.51
+                transition: 35.6
+                minimum: 5.06
+                maximum: 300.0
+                mean_1: 9.76
+                sigma_1: 0.649
+                mean_2: 32.8
+                sigma_2: 3.92
+                taper_range: 4.32
+                lambda_0: 0.361
+                lambda_1: 0.586
+    mass_ratio:
+        intermediate: true
+        sampler:
+            function: planck_tapered_conditional_ratio_power_law
+            arguments:
+                denominator: '@detector_frame_mass_1'
+                beta: 1.26
+                numerator_minimum: 5.06
+                taper_range: 4.32
+                minimum: 0.0
+                maximum: 1.0
+                n_grids: 2048
+    detector_frame_mass_2:
+        transform:
+            function: multiply
+            arguments:
+                left: '@detector_frame_mass_1'
+                right: '@mass_ratio'
+    spin_magnitude_1:
+        intermediate: true
+        transform:
+            function: beta_spin_magnitude
+            arguments:
+                alpha: 2.0
+                beta: 6.0
+                reference: '@detector_frame_mass_1'
+                minimum: 0.0
+                maximum: 0.99
+    spin_magnitude_2:
+        intermediate: true
+        transform:
+            function: beta_spin_magnitude
+            arguments:
+                alpha: 2.0
+                beta: 6.0
+                reference: '@detector_frame_mass_1'
+                minimum: 0.0
+                maximum: 0.99
+    chi_eff:
+        intermediate: true
+        transform:
+            function: gaussian_chi_eff
+            arguments:
+                reference: '@detector_frame_mass_1'
+                mean: 0.0
+                sigma: 0.1
+                minimum: -0.5
+                maximum: 0.5
+    spin_1x:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@detector_frame_mass_1'
+                value: 0.0
+    spin_1y:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@detector_frame_mass_1'
+                value: 0.0
+    spin_1z:
+        transform:
+            function: gaussian_chi_eff
+            arguments:
+                component: primary
+                chi_eff: '@chi_eff'
+                mass_1: '@detector_frame_mass_1'
+                mass_2: '@detector_frame_mass_2'
+                spin_magnitude_1: '@spin_magnitude_1'
+                spin_magnitude_2: '@spin_magnitude_2'
+    spin_2x:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@detector_frame_mass_1'
+                value: 0.0
+    spin_2y:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@detector_frame_mass_1'
+                value: 0.0
+    spin_2z:
+        transform:
+            function: gaussian_chi_eff
+            arguments:
+                component: secondary
+                chi_eff: '@chi_eff'
+                mass_1: '@detector_frame_mass_1'
+                mass_2: '@detector_frame_mass_2'
+                spin_magnitude_1: '@spin_magnitude_1'
+                spin_magnitude_2: '@spin_magnitude_2'
+    eccentricity:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@detector_frame_mass_1'
+                value: 0.0
+    distance:
+        sampler:
+            function: uniform_comoving_volume_distance
+            arguments:
+                d_max: 10000.0
+    coa_phase:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    inclination:
+        transform:
+            function: isotropic_spin_orientation
+            arguments:
+                reference: '@distance'
+    theta_jn:
+        transform:
+            function: isotropic_spin_orientation
+            arguments:
+                reference: '@distance'
+    long_asc_node:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    mean_per_ano:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    coa_time:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    right_ascension:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    declination:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    polarization_angle:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 0.0
+    redshift:
+        transform:
+            function: luminosity_distance_to_redshift
+            arguments:
+                luminosity_distance: '@distance'
+    f_ref:
+        transform:
+            function: constant_like
+            arguments:
+                reference: '@distance'
+                value: 20.0

--- a/src/gwmock_pop/simulators/bbh/base.py
+++ b/src/gwmock_pop/simulators/bbh/base.py
@@ -37,6 +37,7 @@ class BBHSimulator(RandomMixin, Simulator):
         del cls
 
         preset_map = {
+            "gwtc4": "bbh_gwtc4.yaml",
             "power_law_plus_peak": "bbh_power_law_plus_peak.yaml",
         }
         if preset_name not in preset_map:

--- a/tests/cli/test_cli_simulate.py
+++ b/tests/cli/test_cli_simulate.py
@@ -1,50 +1,52 @@
-"""Unit tests for CLI simulate command."""
+"""Tests for the CLI simulate command."""
 
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
+import h5py
 import numpy as np
 import pytest
-import typer
 from typer.testing import CliRunner
 
+from gwmock_pop import FilePopulationLoader
 from gwmock_pop.cli.main import app, setup_logging
-from gwmock_pop.cli.simulate import _build_output_metadata, simulate_command
-from gwmock_pop.config.main import MainConfiguration
-from gwmock_pop.simulators.graph import GraphSimulator
 from gwmock_pop.utils.log import LoggingLevel
 
+_RUNNER = CliRunner()
+_EXPECTED_BBH_COLUMNS = {
+    "detector_frame_mass_1",
+    "detector_frame_mass_2",
+    "spin_1x",
+    "spin_1y",
+    "spin_1z",
+    "spin_2x",
+    "spin_2y",
+    "spin_2z",
+    "eccentricity",
+    "distance",
+    "coa_phase",
+    "inclination",
+    "theta_jn",
+    "long_asc_node",
+    "mean_per_ano",
+    "coa_time",
+    "right_ascension",
+    "declination",
+    "polarization_angle",
+    "redshift",
+    "f_ref",
+}
 
-class TestSimulateCommand:
-    """Test class for simulate command."""
 
-    # Constants for test configuration
-    TEST_N_SAMPLES = 20
-    TEST_SEED = 789
-
-    def test_simulate_command_writes_population(self, tmp_path: Path) -> None:
-        """Test that simulate_command runs GraphSimulator and writes an output file."""
-        output_dir = tmp_path / "outputs"
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            f"""
-config_version: "1.0.0"
-run:
-  name: cli_test
-  seed: 123
-  mode: fixed_n_samples
-  n_samples: 5
-  output:
-    directory: "{output_dir.as_posix()}"
-    format: csv
-    overwrite: true
-    save_metadata: false
+def _minimal_graph_config(path: Path) -> None:
+    """Write a minimal graph config for the file-path CLI route."""
+    path.write_text(
+        """
 parameters:
   mass_1:
     sampler:
-      function: gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks
+      function: planck_tapered_broken_power_law_plus_two_peaks
       arguments:
         alpha_1: 1.72
         alpha_2: 4.51
@@ -58,287 +60,107 @@ parameters:
         taper_range: 4.32
         lambda_0: 0.361
         lambda_1: 0.586
-""",
-            encoding="utf-8",
-        )
+""".strip(),
+        encoding="utf-8",
+    )
 
-        simulate_command(str(config_path))
 
-        output_path = output_dir / "cli_test.csv"
-        assert output_path.exists()
-        loaded = np.loadtxt(output_path, delimiter=",")
-        assert loaded.shape == (5,)
+def test_simulate_command_writes_hdf5_from_packaged_preset(tmp_path: Path) -> None:
+    """The CLI samples the packaged GWTC4 preset into a named-column HDF5 file."""
+    output_path = tmp_path / "population.hdf5"
 
-    @patch("logging.getLogger")
-    def test_simulate_command_rejects_duration_mode(self, mock_get_logger: MagicMock, tmp_path: Path) -> None:
-        """Test that the MVP CLI rejects duration mode explicitly."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+    result = _RUNNER.invoke(
+        app,
+        ["simulate", "--config", "gwtc4", "--n", "100", "--output", str(output_path), "--seed", "42"],
+    )
 
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            """
-run:
-  mode: duration
-parameters:
-  mass_1:
-    sampler:
-      function: gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks
-      arguments:
-        alpha_1: 1.72
-        alpha_2: 4.51
-        transition: 35.6
-        minimum: 5.06
-        maximum: 300.0
-        mean_1: 9.76
-        sigma_1: 0.649
-        mean_2: 32.8
-        sigma_2: 3.92
-        taper_range: 4.32
-        lambda_0: 0.361
-        lambda_1: 0.586
-""",
-            encoding="utf-8",
-        )
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
 
-        with pytest.raises(typer.Exit):
-            simulate_command(str(config_path))
+    with h5py.File(output_path, "r") as handle:
+        dataset = handle["data"]
+        assert dataset.shape == (100,)
+        assert set(dataset.dtype.names or ()) == _EXPECTED_BBH_COLUMNS
 
-        mock_logger.error.assert_called_once_with("Only run.mode='fixed_n_samples' is supported by the CLI MVP.")
 
-    @patch("logging.getLogger")
-    def test_simulate_command_requires_parameters(self, mock_get_logger: MagicMock, tmp_path: Path) -> None:
-        """Test that the simulate command requires parameter graph configuration."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
+def test_simulate_command_writes_csv_from_config_file(tmp_path: Path) -> None:
+    """The CLI samples a graph config file into a header-based CSV file."""
+    config_path = tmp_path / "config.yaml"
+    output_path = tmp_path / "population.csv"
+    _minimal_graph_config(config_path)
 
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            """
-run:
-  mode: fixed_n_samples
-  n_samples: 10
-""",
-            encoding="utf-8",
-        )
+    result = _RUNNER.invoke(
+        app,
+        ["simulate", "--config", str(config_path), "--n", "50", "--output", str(output_path), "--seed", "7"],
+    )
 
-        with pytest.raises(typer.Exit):
-            simulate_command(str(config_path))
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
 
-        mock_logger.error.assert_called_once_with("No parameter graph configuration found under 'parameters'.")
+    data = np.genfromtxt(output_path, delimiter=",", names=True, dtype=float)
+    assert np.atleast_1d(data).shape == (50,)
+    assert data.dtype.names == ("mass_1",)
 
-    @patch("gwmock_pop.cli.simulate._build_output_metadata")
-    def test_simulate_command_with_metadata(self, mock_build_metadata: MagicMock, tmp_path: Path) -> None:
-        """Test that simulate_command builds and saves metadata when requested."""
-        mock_build_metadata.return_value = {"run_name": "cli_test_metadata"}
 
-        output_dir = tmp_path / "outputs"
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            f"""
-config_version: "1.0.0"
-run:
-  name: cli_test_metadata
-  seed: 456
-  mode: fixed_n_samples
-  n_samples: 10
-  output:
-    directory: "{output_dir.as_posix()}"
-    format: csv
-    overwrite: true
-    save_metadata: true
-parameters:
-  mass_1:
-    sampler:
-      function: gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks
-      arguments:
-        alpha_1: 1.72
-        alpha_2: 4.51
-        transition: 35.6
-        minimum: 5.06
-        maximum: 300.0
-        mean_1: 9.76
-        sigma_1: 0.649
-        mean_2: 32.8
-        sigma_2: 3.92
-        taper_range: 4.32
-        lambda_0: 0.361
-        lambda_1: 0.586
-""",
-            encoding="utf-8",
-        )
+@pytest.mark.integration
+def test_hdf5_output_round_trips_through_file_population_loader(tmp_path: Path) -> None:
+    """The CLI HDF5 output is readable through FilePopulationLoader."""
+    output_path = tmp_path / "population.hdf5"
 
-        simulate_command(str(config_path))
-        mock_build_metadata.assert_called_once()
+    result = _RUNNER.invoke(
+        app,
+        ["simulate", "--config", "gwtc4", "--n", "100", "--output", str(output_path), "--seed", "11"],
+    )
 
-        output_path = output_dir / "cli_test_metadata.csv"
-        assert output_path.exists()
+    assert result.exit_code == 0, result.output
 
-    def test_build_output_metadata(self, tmp_path: Path) -> None:
-        """Test that _build_output_metadata builds correct metadata."""
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            f"""
-config_version: "1.0.0"
-run:
-  name: test_metadata
-  seed: {self.TEST_SEED}
-  mode: fixed_n_samples
-  n_samples: {self.TEST_N_SAMPLES}
-  output:
-    directory: "/tmp/test"
-    format: csv
-    overwrite: true
-    save_metadata: false
-parameters:
-  mass_1:
-    sampler:
-      function: gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks
-      arguments:
-        alpha_1: 1.72
-        alpha_2: 4.51
-        transition: 35.6
-        minimum: 5.06
-        maximum: 300.0
-        mean_1: 9.76
-        sigma_1: 0.649
-        mean_2: 32.8
-        sigma_2: 3.92
-        taper_range: 4.32
-        lambda_0: 0.361
-        lambda_1: 0.586
-""",
-            encoding="utf-8",
-        )
+    loader = FilePopulationLoader("bbh", output_path)
+    reloaded = loader.simulate(100, seed=5)
 
-        config = MainConfiguration.from_file(str(config_path))
-        simulator = GraphSimulator(config=config.parameters, seed=config.run.seed)
+    assert len(loader.parameter_names) == 21
+    assert set(loader.parameter_names) == _EXPECTED_BBH_COLUMNS
+    assert set(reloaded) == _EXPECTED_BBH_COLUMNS
+    assert all(values.shape == (100,) for values in reloaded.values())
 
-        metadata = _build_output_metadata(config, simulator)
 
-        assert metadata["config_version"] == "1.0.0"
-        assert metadata["run_name"] == "test_metadata"
-        assert metadata["n_samples"] == self.TEST_N_SAMPLES
-        assert metadata["seed"] == self.TEST_SEED
-        assert "mass_1" in metadata["parameter_names"]
+def test_simulate_command_rejects_existing_output_path(tmp_path: Path) -> None:
+    """The CLI refuses to overwrite an existing output file."""
+    output_path = tmp_path / "population.csv"
+    output_path.write_text("existing\n", encoding="utf-8")
 
-    def test_simulate_command_overwrite_rejection(self, tmp_path: Path) -> None:
-        """Test that simulate_command rejects overwriting without explicit permission."""
-        output_dir = tmp_path / "outputs"
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_path = output_dir / "existing.csv"
-        output_path.write_text("1,2,3\n", encoding="utf-8")
+    result = _RUNNER.invoke(app, ["simulate", "--config", "gwtc4", "--n", "10", "--output", str(output_path)])
 
-        config_path = tmp_path / "config.yaml"
-        config_path.write_text(
-            f"""
-config_version: "1.0.0"
-run:
-  name: existing
-  seed: 111
-  mode: fixed_n_samples
-  n_samples: 5
-  output:
-    directory: "{output_dir.as_posix()}"
-    format: csv
-    overwrite: false
-    save_metadata: false
-parameters:
-  mass_1:
-    sampler:
-      function: gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks
-      arguments:
-        alpha_1: 1.72
-        alpha_2: 4.51
-        transition: 35.6
-        minimum: 5.06
-        maximum: 300.0
-        mean_1: 9.76
-        sigma_1: 0.649
-        mean_2: 32.8
-        sigma_2: 3.92
-        taper_range: 4.32
-        lambda_0: 0.361
-        lambda_1: 0.586
-""",
-            encoding="utf-8",
-        )
+    assert result.exit_code == 1
+    assert "Refusing to overwrite existing output file" in result.output
 
-        with pytest.raises(typer.Exit):
-            simulate_command(str(config_path))
 
-        assert output_path.exists()
+def test_simulate_command_rejects_unknown_config_target(tmp_path: Path) -> None:
+    """Unknown preset names and missing config files fail clearly."""
+    output_path = tmp_path / "population.hdf5"
+
+    result = _RUNNER.invoke(
+        app,
+        ["simulate", "--config", "does-not-exist", "--n", "10", "--output", str(output_path)],
+    )
+
+    assert result.exit_code == 1
+    assert "Unknown preset or configuration path" in result.output
 
 
 class TestSetupLogging:
-    """Test class for setup_logging function."""
+    """Smoke tests for logging setup."""
 
     def test_setup_logging_with_info_level(self) -> None:
-        """Test that setup_logging sets up logging with INFO level."""
+        """INFO setup does not raise."""
         setup_logging(LoggingLevel.INFO)
-        # Just verify it doesn't raise an exception
         assert True
 
     def test_setup_logging_with_debug_level(self) -> None:
-        """Test that setup_logging sets up logging with DEBUG level."""
+        """DEBUG setup does not raise."""
         setup_logging(LoggingLevel.DEBUG)
-        # Just verify it doesn't raise an exception
         assert True
 
     def test_setup_logging_with_error_level(self) -> None:
-        """Test that setup_logging sets up logging with ERROR level."""
+        """ERROR setup does not raise."""
         setup_logging(LoggingLevel.ERROR)
-        # Just verify it doesn't raise an exception
         assert True
-
-
-class TestVersionCallback:
-    """Test class for version callback function."""
-
-    def test_version_callback_logs_version(self) -> None:
-        """Test that version_callback logs version and raises Exit."""
-        runner = CliRunner()
-        result = runner.invoke(app, ["--version"])
-        assert result.exit_code == 0
-        # Version output goes to stderr via logging
-        assert (
-            "gwmock_pop version:" in result.stdout
-            or "gwmock_pop version:" in result.stderr
-            or "gwmock_pop version:" in str(result)
-        )
-
-
-class TestSimulateCommandErrorHandling:
-    """Test class for simulate command error handling."""
-
-    def test_simulate_command_file_not_found(self) -> None:
-        """Test that simulate_command raises typer.Exit for non-existent file."""
-        with pytest.raises(typer.Exit):
-            simulate_command("nonexistent_config.yaml")
-
-    @patch("logging.getLogger")
-    def test_simulate_command_validation_error(self, mock_get_logger: MagicMock, tmp_path: Path) -> None:
-        """Test that simulate_command handles validation errors."""
-        mock_logger = MagicMock()
-        mock_get_logger.return_value = mock_logger
-
-        config_path = tmp_path / "invalid_config.yaml"
-        config_path.write_text(
-            """
-# Invalid config - missing required fields
-run:
-  mode: fixed_n_samples
-""",
-            encoding="utf-8",
-        )
-
-        with pytest.raises(typer.Exit):
-            simulate_command(str(config_path))
-
-    def test_simulate_command_empty_config(self, tmp_path: Path) -> None:
-        """Test that simulate_command handles empty config file."""
-        config_path = tmp_path / "empty_config.yaml"
-        config_path.write_text("", encoding="utf-8")
-
-        with pytest.raises(typer.Exit):
-            simulate_command(str(config_path))

--- a/tests/simulators/bbh/test_simulators_bbh_preset.py
+++ b/tests/simulators/bbh/test_simulators_bbh_preset.py
@@ -55,6 +55,44 @@ def test_from_preset_returns_protocol_conformant_simulator() -> None:
     assert bool(jnp.all(result["detector_frame_mass_2"] <= result["detector_frame_mass_1"]))
 
 
+def test_gwtc4_preset_returns_canonical_bbh_surface() -> None:
+    """The GWTC4 preset exposes the full canonical BBH parameter set."""
+    simulator = BBHSimulator.from_preset("gwtc4", seed=42)
+
+    result = simulator.simulate(64)
+
+    assert isinstance(simulator, GWPopSimulator)
+    assert simulator.source_type == "bbh"
+    assert list(result.keys()) == list(simulator.parameter_names)
+    assert len(result) == 21
+    assert list(result.keys()) == [
+        "detector_frame_mass_1",
+        "detector_frame_mass_2",
+        "spin_1x",
+        "spin_1y",
+        "spin_1z",
+        "spin_2x",
+        "spin_2y",
+        "spin_2z",
+        "eccentricity",
+        "distance",
+        "coa_phase",
+        "inclination",
+        "theta_jn",
+        "long_asc_node",
+        "mean_per_ano",
+        "coa_time",
+        "right_ascension",
+        "declination",
+        "polarization_angle",
+        "redshift",
+        "f_ref",
+    ]
+    assert all(array.shape == (64,) for array in result.values())
+    assert bool(jnp.all(jnp.isfinite(result["distance"])))
+    assert bool(jnp.all(jnp.isfinite(result["redshift"])))
+
+
 def test_from_preset_rejects_unknown_preset_name() -> None:
     """Unknown preset names raise a helpful error."""
     with pytest.raises(ValueError, match="Unknown BBH preset"):

--- a/tests/simulators/test_cbc_integration.py
+++ b/tests/simulators/test_cbc_integration.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from importlib.resources import as_file, files
 
 import jax.numpy as jnp
 import pytest
@@ -12,25 +12,24 @@ from gwmock_pop.simulators import GraphSimulator
 
 pytestmark = pytest.mark.integration
 
-_GWTC4_CONFIG_PATH = Path(__file__).resolve().parents[2] / "examples" / "gwtc4" / "bbh_population.yaml"
-
 
 def test_bbh_end_to_end_via_protocol() -> None:
     """Exercise the full BBH config-file path through the public protocol API."""
     n_samples = 100
-    sim: GWPopSimulator = GraphSimulator.from_config_file(_GWTC4_CONFIG_PATH, source_type="bbh", seed=42)
+    with as_file(files("gwmock_pop.configs").joinpath("bbh_gwtc4.yaml")) as config_path:
+        sim: GWPopSimulator = GraphSimulator.from_config_file(config_path, source_type="bbh", seed=42)
 
-    assert isinstance(sim, GWPopSimulator)
-    assert sim.source_type == "bbh"
+        assert isinstance(sim, GWPopSimulator)
+        assert sim.source_type == "bbh"
 
-    result = sim.simulate(n_samples)
+        result = sim.simulate(n_samples)
 
-    assert list(result.keys()) == list(sim.parameter_names)
-    assert set(result.keys()) == set(sim.parameter_names)
-    assert all(values.shape == (n_samples,) for values in result.values())
-    assert all(bool(jnp.all(jnp.isfinite(values))) for values in result.values())
+        assert list(result.keys()) == list(sim.parameter_names)
+        assert set(result.keys()) == set(sim.parameter_names)
+        assert all(values.shape == (n_samples,) for values in result.values())
+        assert all(bool(jnp.all(jnp.isfinite(values))) for values in result.values())
 
-    single = {key: float(values[0]) for key, values in result.items()}
-    assert isinstance(single, dict)
-    assert all(isinstance(key, str) for key in single)
-    assert all(isinstance(value, float) for value in single.values())
+        single = {key: float(values[0]) for key, values in result.items()}
+        assert isinstance(single, dict)
+        assert all(isinstance(key, str) for key in single)
+        assert all(isinstance(value, float) for value in single.values())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GWTC4 preset configuration for binary black hole population simulation
  * CLI simulate command now supports automatic output format detection based on file extension (CSV/HDF5)
  * Added optional `--seed` parameter for reproducible simulation results

* **Improvements**
  * Simulate command now prevents accidental overwrites of existing output files

* **Documentation**
  * Updated README CI badge URL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->