### PR TITLE
feat: Add a gwmock-pop inspect CLI subcommand that draws a small sample and prints per-parameter summary statistics for quick sanity-checking of a config or preset

### DIFF
--- a/src/gwmock_pop/cli/common.py
+++ b/src/gwmock_pop/cli/common.py
@@ -14,9 +14,13 @@ _CONFIG_FILE_SUFFIXES = {".yaml", ".yml", ".toml"}
 def resolve_simulator(config: str, seed: int | None) -> GWPopSimulator:
     """Build a simulator from either a packaged preset name or a config-file path."""
     config_path = Path(config).expanduser()
-    if config_path.exists():
+    if config_path.is_file():
+        if config_path.suffix.lower() not in _CONFIG_FILE_SUFFIXES:
+            supported = ", ".join(sorted(_CONFIG_FILE_SUFFIXES))
+            raise ValueError(f"Unsupported config-file suffix for {config_path}. Supported suffixes: {supported}.")
         return GraphSimulator.from_config_file(config_path, source_type="bbh", seed=seed)
-
+    if config_path.exists():
+        raise ValueError(f"Configuration path is not a file: {config_path}")
     try:
         return BBHSimulator.from_preset(config, seed=seed)
     except ValueError as error:

--- a/src/gwmock_pop/cli/common.py
+++ b/src/gwmock_pop/cli/common.py
@@ -1,0 +1,25 @@
+"""Shared helpers for simulator-backed CLI commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gwmock_pop.protocols import GWPopSimulator
+from gwmock_pop.simulators.bbh.base import BBHSimulator
+from gwmock_pop.simulators.graph import GraphSimulator
+
+_CONFIG_FILE_SUFFIXES = {".yaml", ".yml", ".toml"}
+
+
+def resolve_simulator(config: str, seed: int | None) -> GWPopSimulator:
+    """Build a simulator from either a packaged preset name or a config-file path."""
+    config_path = Path(config).expanduser()
+    if config_path.exists():
+        return GraphSimulator.from_config_file(config_path, source_type="bbh", seed=seed)
+
+    try:
+        return BBHSimulator.from_preset(config, seed=seed)
+    except ValueError as error:
+        if config_path.suffix.lower() in _CONFIG_FILE_SUFFIXES:
+            raise FileNotFoundError(f"Configuration file does not exist: {config_path}") from error
+        raise ValueError(f"Unknown preset or configuration path {config!r}.") from error

--- a/src/gwmock_pop/cli/inspect.py
+++ b/src/gwmock_pop/cli/inspect.py
@@ -1,0 +1,104 @@
+"""Inspect populations from packaged presets or graph config files."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Annotated
+
+import numpy as np
+import typer
+from jax import Array
+
+from gwmock_pop.cli.common import resolve_simulator
+from gwmock_pop.protocols import GWPopSimulator
+
+
+@dataclass(frozen=True)
+class ParameterSummary:
+    """Summary statistics for one sampled parameter."""
+
+    parameter: str
+    mean: float
+    std: float
+    p5: float
+    p95: float
+    minimum: float
+    maximum: float
+
+
+def _ordered_parameter_names(simulator: GWPopSimulator, population: Mapping[str, Array]) -> list[str]:
+    """Return a stable output order for the inspected population."""
+    preferred = [name for name in simulator.parameter_names if name in population]
+    remaining = [name for name in population if name not in preferred]
+    return preferred + remaining
+
+
+def _summarize_population(simulator: GWPopSimulator, population: Mapping[str, Array]) -> list[ParameterSummary]:
+    """Compute scalar summary statistics for each sampled parameter."""
+    summaries: list[ParameterSummary] = []
+    for parameter in _ordered_parameter_names(simulator=simulator, population=population):
+        values = np.asarray(population[parameter], dtype=float)
+        p5, p95 = np.percentile(values, [5, 95])
+        summaries.append(
+            ParameterSummary(
+                parameter=parameter,
+                mean=float(np.mean(values)),
+                std=float(np.std(values)),
+                p5=float(p5),
+                p95=float(p95),
+                minimum=float(np.min(values)),
+                maximum=float(np.max(values)),
+            )
+        )
+    return summaries
+
+
+def _format_float(value: float) -> str:
+    """Format a summary-statistic value for tabular output."""
+    return f"{value:.6g}"
+
+
+def render_summary_table(summaries: list[ParameterSummary]) -> str:
+    """Render a parameter-summary table for stdout output."""
+    header = ["Parameter", "Mean", "Std", "P5", "P95", "Min", "Max"]
+    rows = [
+        [
+            summary.parameter,
+            _format_float(summary.mean),
+            _format_float(summary.std),
+            _format_float(summary.p5),
+            _format_float(summary.p95),
+            _format_float(summary.minimum),
+            _format_float(summary.maximum),
+        ]
+        for summary in summaries
+    ]
+    widths = [max(len(cell) for cell in column) for column in zip(header, *rows, strict=False)]
+
+    def render_row(cells: list[str]) -> str:
+        return "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True))
+
+    separator = "  ".join("-" * width for width in widths)
+    return "\n".join([render_row(header), separator, *(render_row(row) for row in rows)])
+
+
+def inspect_command(
+    config: Annotated[str, typer.Option("--config", help="Preset name or YAML/TOML config-file path.")],
+    n: Annotated[int, typer.Option("--n", min=1, help="Number of events to sample.")] = 1000,
+    seed: Annotated[int | None, typer.Option("--seed", help="Optional random seed.")] = None,
+) -> None:
+    """Draw a quick sample and print per-parameter summary statistics."""
+    import logging  # noqa: PLC0415
+
+    logger = logging.getLogger("gwmock_pop")
+
+    try:
+        simulator = resolve_simulator(config=config, seed=seed)
+        population = simulator.simulate(n)
+        summaries = _summarize_population(simulator=simulator, population=population)
+    except Exception as error:
+        logger.error("%s", error)
+        raise typer.Exit(1) from error
+
+    typer.echo(render_summary_table(summaries))

--- a/src/gwmock_pop/cli/main.py
+++ b/src/gwmock_pop/cli/main.py
@@ -94,9 +94,11 @@ def main(
 
 def register_commands() -> None:
     """Register CLI commands."""
+    from gwmock_pop.cli.inspect import inspect_command  # noqa: PLC0415
     from gwmock_pop.cli.simulate import simulate_command  # noqa: PLC0415
     from gwmock_pop.cli.validate import validate_command  # noqa: PLC0415
 
+    app.command("inspect", help="Inspect populations with quick summary statistics.")(inspect_command)
     app.command("simulate", help="Simulate populations.")(simulate_command)
     app.command("validate", help="Validate graph configs without sampling.")(validate_command)
 

--- a/src/gwmock_pop/cli/simulate.py
+++ b/src/gwmock_pop/cli/simulate.py
@@ -11,13 +11,10 @@ import numpy as np
 import typer
 from jax import Array
 
-from gwmock_pop.protocols import GWPopSimulator
-from gwmock_pop.simulators.bbh.base import BBHSimulator
-from gwmock_pop.simulators.graph import GraphSimulator
+from gwmock_pop.cli.common import resolve_simulator
 
 _HDF5_DATASET_NAME = "data"
 _SUPPORTED_OUTPUT_SUFFIXES = {".csv": "csv", ".hdf5": "hdf5", ".h5": "hdf5"}
-_CONFIG_FILE_SUFFIXES = {".yaml", ".yml", ".toml"}
 
 
 def _infer_output_format(output_path: Path) -> str:
@@ -27,20 +24,6 @@ def _infer_output_format(output_path: Path) -> str:
         supported = ", ".join(sorted(_SUPPORTED_OUTPUT_SUFFIXES))
         raise ValueError(f"Unsupported output format for {output_path}. Supported suffixes: {supported}.")
     return file_format
-
-
-def _resolve_simulator(config: str, seed: int | None) -> GWPopSimulator:
-    """Build a simulator from either a packaged preset name or a config-file path."""
-    config_path = Path(config).expanduser()
-    if config_path.exists():
-        return GraphSimulator.from_config_file(config_path, source_type="bbh", seed=seed)
-
-    try:
-        return BBHSimulator.from_preset(config, seed=seed)
-    except ValueError as error:
-        if config_path.suffix.lower() in _CONFIG_FILE_SUFFIXES:
-            raise FileNotFoundError(f"Configuration file does not exist: {config_path}") from error
-        raise ValueError(f"Unknown preset or configuration path {config!r}.") from error
 
 
 def _population_columns(population: Mapping[str, Array]) -> list[str]:
@@ -117,7 +100,7 @@ def simulate_command(
     logger = logging.getLogger("gwmock_pop")
 
     try:
-        simulator = _resolve_simulator(config=config, seed=seed)
+        simulator = resolve_simulator(config=config, seed=seed)
         output_path = output.expanduser()
         _infer_output_format(output_path)
     except Exception as error:

--- a/tests/cli/test_cli_inspect.py
+++ b/tests/cli/test_cli_inspect.py
@@ -1,0 +1,49 @@
+"""Tests for the CLI inspect command."""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+from typer.testing import CliRunner
+
+from gwmock_pop.cli.main import app
+from gwmock_pop.simulators.bbh.base import BBHSimulator
+
+_RUNNER = CliRunner()
+
+
+def _parse_summary_rows(output: str) -> dict[str, list[float]]:
+    """Parse the inspect command's summary table into numeric rows."""
+    lines = [line for line in output.splitlines() if line.strip()]
+    data_lines = lines[2:]
+    rows: dict[str, list[float]] = {}
+    for line in data_lines:
+        columns = re.split(r"\s{2,}", line.strip())
+        assert len(columns) == 7, line
+        rows[columns[0]] = [float(value) for value in columns[1:]]
+    return rows
+
+
+def test_inspect_command_prints_all_canonical_bbh_parameters_with_finite_statistics() -> None:
+    """The inspect CLI prints one finite summary row per canonical BBH parameter."""
+    result = _RUNNER.invoke(app, ["inspect", "--config", "gwtc4", "--seed", "42"])
+
+    assert result.exit_code == 0, result.output
+    assert "Parameter" in result.output
+    assert "P95" in result.output
+
+    rows = _parse_summary_rows(result.output)
+    expected_parameters = set(BBHSimulator.from_preset("gwtc4").parameter_names)
+
+    assert set(rows) == expected_parameters
+    for statistics in rows.values():
+        assert np.isfinite(np.asarray(statistics)).all()
+
+
+def test_inspect_command_rejects_unknown_config_target() -> None:
+    """Unknown preset names and missing config files fail clearly."""
+    result = _RUNNER.invoke(app, ["inspect", "--config", "/bad/path"])
+
+    assert result.exit_code == 1
+    assert "Unknown preset or configuration path '/bad/path'." in result.output


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added an `inspect` CLI command that analyzes population simulators from presets or config files. The command generates simulated events and computes per-parameter statistics (mean, standard deviation, 5th/95th percentiles, minimum, and maximum), displaying results in a formatted table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->