### PR TITLE
feat: Add a gwmock-pop list CLI subcommand that enumerates all available built-in presets and simulator classes with one-line descriptions

### DIFF
--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
+    BBHSimulator,
     BNSPriorSimulator,
     CBCPriorSimulator,
+    GraphSimulator,
     MixtureSimulator,
     NSBHPriorSimulator,
     PoissonEventSampler,
@@ -14,11 +16,13 @@ from gwmock_pop.simulators import (
 from gwmock_pop.version import __version__
 
 __all__ = [
+    "BBHSimulator",
     "BNSPriorSimulator",
     "CBCPriorSimulator",
     "ExternalPopulationLoader",
     "FilePopulationLoader",
     "GWPopSimulator",
+    "GraphSimulator",
     "MixtureSimulator",
     "NSBHPriorSimulator",
     "PoissonEventSampler",

--- a/src/gwmock_pop/cli/list.py
+++ b/src/gwmock_pop/cli/list.py
@@ -1,0 +1,80 @@
+"""List packaged presets and public simulator classes."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+
+import typer
+
+import gwmock_pop
+from gwmock_pop.configs import PackagedPreset, iter_packaged_presets
+from gwmock_pop.simulators.simulator import Simulator
+
+
+@dataclass(frozen=True)
+class SimulatorSummary:
+    """Rendered metadata for one public simulator class."""
+
+    name: str
+    description: str
+
+
+def _first_docstring_line(obj: object) -> str:
+    """Return the first non-empty docstring line for display."""
+    docstring = inspect.getdoc(obj) or ""
+    return next((line.strip() for line in docstring.splitlines() if line.strip()), "")
+
+
+def _render_table(header: list[str], rows: list[list[str]]) -> str:
+    """Render a plain-text table with aligned columns."""
+    widths = [max(len(cell) for cell in column) for column in zip(header, *rows, strict=False)]
+
+    def render_row(cells: list[str]) -> str:
+        return "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True))
+
+    separator = "  ".join("-" * width for width in widths)
+    return "\n".join([render_row(header), separator, *(render_row(row) for row in rows)])
+
+
+def _discover_public_simulator_classes() -> list[SimulatorSummary]:
+    """Return top-level public simulator classes exposed by ``gwmock_pop``."""
+    simulators: list[SimulatorSummary] = []
+    for public_name in getattr(gwmock_pop, "__all__", []):
+        candidate = getattr(gwmock_pop, public_name)
+        if not inspect.isclass(candidate) or not issubclass(candidate, Simulator) or candidate is Simulator:
+            continue
+        simulators.append(SimulatorSummary(name=public_name, description=_first_docstring_line(candidate)))
+    return sorted(simulators, key=lambda simulator: simulator.name)
+
+
+def _render_presets_table(presets: list[PackagedPreset]) -> str:
+    """Render the packaged preset table."""
+    rows = [[preset.name, preset.source_type, preset.description] for preset in presets]
+    return _render_table(header=["Name", "Source type", "Description"], rows=rows)
+
+
+def _render_simulators_table(simulators: list[SimulatorSummary]) -> str:
+    """Render the public simulator-class table."""
+    rows = [[simulator.name, simulator.description] for simulator in simulators]
+    return _render_table(header=["Class", "Description"], rows=rows)
+
+
+def list_command() -> None:
+    """Print packaged preset metadata and public simulator classes."""
+    import logging  # noqa: PLC0415
+
+    logger = logging.getLogger("gwmock_pop")
+
+    try:
+        presets = iter_packaged_presets()
+        simulators = _discover_public_simulator_classes()
+    except Exception as error:
+        logger.error("%s", error)
+        raise typer.Exit(1) from error
+
+    typer.echo("Presets")
+    typer.echo(_render_presets_table(presets))
+    typer.echo("")
+    typer.echo("Simulator classes")
+    typer.echo(_render_simulators_table(simulators))

--- a/src/gwmock_pop/cli/main.py
+++ b/src/gwmock_pop/cli/main.py
@@ -95,10 +95,12 @@ def main(
 def register_commands() -> None:
     """Register CLI commands."""
     from gwmock_pop.cli.inspect import inspect_command  # noqa: PLC0415
+    from gwmock_pop.cli.list import list_command  # noqa: PLC0415
     from gwmock_pop.cli.simulate import simulate_command  # noqa: PLC0415
     from gwmock_pop.cli.validate import validate_command  # noqa: PLC0415
 
     app.command("inspect", help="Inspect populations with quick summary statistics.")(inspect_command)
+    app.command("list", help="List packaged presets and public simulator classes.")(list_command)
     app.command("simulate", help="Simulate populations.")(simulate_command)
     app.command("validate", help="Validate graph configs without sampling.")(validate_command)
 

--- a/src/gwmock_pop/configs/__init__.py
+++ b/src/gwmock_pop/configs/__init__.py
@@ -61,12 +61,13 @@ def iter_packaged_presets() -> list[PackagedPreset]:
 
 def get_packaged_preset_resource(preset_name: str) -> Traversable:
     """Return the packaged config resource for a named preset."""
-    for preset in iter_packaged_presets():
+    presets = iter_packaged_presets()
+    for preset in presets:
         if preset.name == preset_name:
             return files(__name__).joinpath(preset.resource_name)
 
-    available = ", ".join(preset.name for preset in iter_packaged_presets())
-    raise ValueError(f"Unknown BBH preset {preset_name!r}. Available presets: {available}.")
+    available = ", ".join(p.name for p in presets)
+    raise ValueError(f"Unknown preset {preset_name!r}. Available presets: {available}.")
 
 
 __all__ = ["PackagedPreset", "get_packaged_preset_resource", "iter_packaged_presets"]

--- a/src/gwmock_pop/configs/__init__.py
+++ b/src/gwmock_pop/configs/__init__.py
@@ -1,1 +1,72 @@
 """Packaged graph-simulator preset configurations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.resources import as_file, files
+from importlib.resources.abc import Traversable
+from pathlib import Path
+
+from gwmock_pop.utils.yaml import read_data_file
+
+_SUPPORTED_CONFIG_SUFFIXES = {".yaml", ".yml", ".toml"}
+_REQUIRED_PRESET_FIELDS = ("name", "source_type", "description", "parameters")
+
+
+@dataclass(frozen=True)
+class PackagedPreset:
+    """Metadata for one packaged simulator preset."""
+
+    name: str
+    source_type: str
+    description: str
+    resource_name: str
+
+
+def _iter_preset_resources() -> list[Traversable]:
+    """Return packaged config resources that represent built-in presets."""
+    return sorted(
+        (
+            resource
+            for resource in files(__name__).iterdir()
+            if resource.is_file() and Path(resource.name).suffix.lower() in _SUPPORTED_CONFIG_SUFFIXES
+        ),
+        key=lambda resource: resource.name,
+    )
+
+
+def iter_packaged_presets() -> list[PackagedPreset]:
+    """Return metadata for all packaged presets."""
+    presets: list[PackagedPreset] = []
+    for resource in _iter_preset_resources():
+        with as_file(resource) as config_path:
+            config = read_data_file(config_path)
+
+        missing = [field for field in _REQUIRED_PRESET_FIELDS if field not in config]
+        if missing:
+            missing_fields = ", ".join(missing)
+            raise ValueError(f"Packaged preset {resource.name} is missing required metadata fields: {missing_fields}.")
+
+        presets.append(
+            PackagedPreset(
+                name=str(config["name"]),
+                source_type=str(config["source_type"]),
+                description=str(config["description"]),
+                resource_name=resource.name,
+            )
+        )
+
+    return sorted(presets, key=lambda preset: preset.name)
+
+
+def get_packaged_preset_resource(preset_name: str) -> Traversable:
+    """Return the packaged config resource for a named preset."""
+    for preset in iter_packaged_presets():
+        if preset.name == preset_name:
+            return files(__name__).joinpath(preset.resource_name)
+
+    available = ", ".join(preset.name for preset in iter_packaged_presets())
+    raise ValueError(f"Unknown BBH preset {preset_name!r}. Available presets: {available}.")
+
+
+__all__ = ["PackagedPreset", "get_packaged_preset_resource", "iter_packaged_presets"]

--- a/src/gwmock_pop/configs/bbh_gwtc4.yaml
+++ b/src/gwmock_pop/configs/bbh_gwtc4.yaml
@@ -1,3 +1,8 @@
+name: gwtc4
+source_type: bbh
+description:
+    GWTC-4-inspired BBH graph preset with masses, spins, distance, and extrinsic
+    parameters.
 parameters:
     detector_frame_mass_1:
         sampler:

--- a/src/gwmock_pop/configs/bbh_power_law_plus_peak.yaml
+++ b/src/gwmock_pop/configs/bbh_power_law_plus_peak.yaml
@@ -1,3 +1,8 @@
+name: power_law_plus_peak
+source_type: bbh
+description:
+    Talbot-Thrane-inspired BBH mass graph preset with a power law, Gaussian
+    peak, and mass-ratio pairing.
 parameters:
     detector_frame_mass_1:
         sampler:

--- a/src/gwmock_pop/simulators/__init__.py
+++ b/src/gwmock_pop/simulators/__init__.py
@@ -6,6 +6,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .bbh.base import BBHSimulator
     from .bns_prior import BNSPriorSimulator
     from .cbc_prior import CBCPriorSimulator
     from .graph import GraphSimulator
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     from .simulator import Simulator
 
 __all__ = [
+    "BBHSimulator",
     "BNSPriorSimulator",
     "CBCPriorSimulator",
     "GraphSimulator",
@@ -28,6 +30,7 @@ __all__ = [
 def __getattr__(name: str) -> Any:
     """Lazily import simulator classes for package-level access."""
     module_map = {
+        "BBHSimulator": ".bbh.base",
         "BNSPriorSimulator": ".bns_prior",
         "CBCPriorSimulator": ".cbc_prior",
         "GraphSimulator": ".graph",

--- a/src/gwmock_pop/simulators/bbh/base.py
+++ b/src/gwmock_pop/simulators/bbh/base.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from importlib.resources import as_file, files
+from importlib.resources import as_file
 from typing import Any
 
+from gwmock_pop.configs import get_packaged_preset_resource
 from gwmock_pop.mixins.random import RandomMixin
 from gwmock_pop.simulators.graph import GraphSimulator
 from gwmock_pop.simulators.simulator import Simulator
@@ -36,17 +37,9 @@ class BBHSimulator(RandomMixin, Simulator):
         """
         del cls
 
-        preset_map = {
-            "gwtc4": "bbh_gwtc4.yaml",
-            "power_law_plus_peak": "bbh_power_law_plus_peak.yaml",
-        }
-        if preset_name not in preset_map:
-            available = ", ".join(sorted(preset_map))
-            raise ValueError(f"Unknown BBH preset {preset_name!r}. Available presets: {available}.")
-
         options = dict(kwargs)
         options.setdefault("source_type", "bbh")
-        with as_file(files("gwmock_pop.configs").joinpath(preset_map[preset_name])) as config_path:
+        with as_file(get_packaged_preset_resource(preset_name)) as config_path:
             return GraphSimulator.from_config_file(config_path, **options)
 
     @property

--- a/tests/cli/test_cli_list.py
+++ b/tests/cli/test_cli_list.py
@@ -1,0 +1,27 @@
+"""Tests for the CLI list command."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from gwmock_pop.cli.main import app
+
+_RUNNER = CliRunner()
+
+
+def test_list_command_prints_packaged_presets_and_public_simulator_classes() -> None:
+    """The list CLI prints preset metadata and public simulator-class descriptions."""
+    result = _RUNNER.invoke(app, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "Presets" in result.output
+    assert "Name" in result.output
+    assert "Source type" in result.output
+    assert "Description" in result.output
+    assert "gwtc4" in result.output
+    assert "power_law_plus_peak" in result.output
+    assert "GWTC-4-inspired BBH graph preset" in result.output
+    assert "Talbot-Thrane-inspired BBH mass graph preset" in result.output
+    assert "Simulator classes" in result.output
+    assert "BBHSimulator" in result.output
+    assert "CBCPriorSimulator" in result.output

--- a/tests/simulators/bbh/test_simulators_bbh_preset.py
+++ b/tests/simulators/bbh/test_simulators_bbh_preset.py
@@ -95,7 +95,7 @@ def test_gwtc4_preset_returns_canonical_bbh_surface() -> None:
 
 def test_from_preset_rejects_unknown_preset_name() -> None:
     """Unknown preset names raise a helpful error."""
-    with pytest.raises(ValueError, match="Unknown BBH preset"):
+    with pytest.raises(ValueError, match="Unknown preset"):
         BBHSimulator.from_preset("does_not_exist")
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `list` CLI command to discover and display all available presets and public simulator classes with descriptions.
  * Added new preset configurations for BBH simulations: `gwtc4` (GWTC-4-inspired) and `power_law_plus_peak` (power-law mass generation).

* **Tests**
  * Added tests for the new list command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->