### PR TITLE
feat: Add a gwmock-pop convert CLI subcommand that converts a population file between HDF5 and CSV formats with optional column remapping to canonical gwmock-pop parameter names

### DIFF
--- a/src/gwmock_pop/cli/convert.py
+++ b/src/gwmock_pop/cli/convert.py
@@ -55,14 +55,15 @@ def _filter_canonical_columns(
     raw_catalogue: dict[str, np.ndarray], column_map: dict[str, str], canonical_names: set[str]
 ) -> tuple[dict[str, np.ndarray], list[tuple[str, str]], list[str]]:
     """Keep only canonical columns after applying the optional renaming map."""
-    apply_population_column_map(raw_catalogue, column_map)
+    renamed_catalogue = apply_population_column_map(raw_catalogue, column_map)
 
     converted: dict[str, np.ndarray] = {}
     renamed_columns: list[tuple[str, str]] = []
     skipped_columns: list[str] = []
 
-    for source_name, values in raw_catalogue.items():
-        target_name = column_map.get(source_name, source_name)
+    reverse_map = {v: k for k, v in column_map.items()}
+    for target_name, values in renamed_catalogue.items():
+        source_name = reverse_map.get(target_name, target_name)
         if target_name != source_name:
             renamed_columns.append((source_name, target_name))
         if target_name not in canonical_names:

--- a/src/gwmock_pop/cli/convert.py
+++ b/src/gwmock_pop/cli/convert.py
@@ -1,0 +1,153 @@
+"""Convert named-column population catalogues between CSV and HDF5."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import numpy as np
+import typer
+
+from gwmock_pop.loaders.file_loader import (
+    apply_population_column_map,
+    infer_population_file_format,
+    read_population_catalogue,
+    write_population_catalogue,
+)
+from gwmock_pop.simulators.cbc_prior import CBCPriorSimulator
+from gwmock_pop.utils.yaml import read_yaml
+
+
+def _load_column_map(path: Path) -> dict[str, str]:
+    """Load a JSON or YAML source-to-canonical column mapping from disk."""
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    elif suffix in {".yaml", ".yml"}:
+        data = read_yaml(path)
+    else:
+        raise ValueError(f"Unsupported column-map format for {path}. Supported suffixes: .json, .yaml, .yml.")
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Column map {path} must contain a top-level mapping.")
+    if any(not isinstance(key, str) or not isinstance(value, str) for key, value in data.items()):
+        raise ValueError(f"Column map {path} must map string source columns to string canonical names.")
+    return data
+
+
+def _canonical_parameter_names() -> set[str]:
+    """Return the canonical gwmock-pop parameter names accepted by the converter."""
+    return set(CBCPriorSimulator().parameter_names)
+
+
+def _validate_column_map_targets(column_map: dict[str, str], canonical_names: set[str]) -> None:
+    """Reject column maps that point at unknown canonical target names."""
+    invalid_targets = sorted({target for target in column_map.values() if target not in canonical_names})
+    if invalid_targets:
+        raise ValueError(
+            f"Column map targets must be canonical gwmock-pop parameter names. Invalid targets: {invalid_targets}"
+        )
+
+
+def _filter_canonical_columns(
+    raw_catalogue: dict[str, np.ndarray], column_map: dict[str, str], canonical_names: set[str]
+) -> tuple[dict[str, np.ndarray], list[tuple[str, str]], list[str]]:
+    """Keep only canonical columns after applying the optional renaming map."""
+    apply_population_column_map(raw_catalogue, column_map)
+
+    converted: dict[str, np.ndarray] = {}
+    renamed_columns: list[tuple[str, str]] = []
+    skipped_columns: list[str] = []
+
+    for source_name, values in raw_catalogue.items():
+        target_name = column_map.get(source_name, source_name)
+        if target_name != source_name:
+            renamed_columns.append((source_name, target_name))
+        if target_name not in canonical_names:
+            skipped_columns.append(source_name)
+            continue
+        converted[target_name] = values
+
+    return converted, renamed_columns, skipped_columns
+
+
+def _render_conversion_summary(
+    output_path: Path,
+    population: dict[str, np.ndarray],
+    renamed_columns: list[tuple[str, str]],
+    skipped_columns: list[str],
+) -> str:
+    """Render a human-readable conversion summary."""
+    row_count = 0 if not population else len(next(iter(population.values())))
+    lines = [
+        f"Converted {row_count} rows to {output_path}.",
+        "Retained columns: " + (", ".join(population) if population else "none"),
+    ]
+    if renamed_columns:
+        lines.append("Renamed columns:")
+        lines.extend(f"  {source} -> {target}" for source, target in renamed_columns)
+    else:
+        lines.append("Renamed columns: none")
+    if skipped_columns:
+        lines.append("Skipped columns: " + ", ".join(skipped_columns))
+    else:
+        lines.append("Skipped columns: none")
+    return "\n".join(lines)
+
+
+def convert_command(
+    input_path_arg: Annotated[Path, typer.Option("--input", help="Source .csv, .h5, or .hdf5 population file.")],
+    output: Annotated[Path, typer.Option("--output", help="Destination .csv, .h5, or .hdf5 population file.")],
+    column_map: Annotated[
+        Path | None,
+        typer.Option("--column-map", help="Optional JSON/YAML mapping from source columns to canonical names."),
+    ] = None,
+) -> None:
+    """Convert a named-column population file between CSV and HDF5 formats."""
+    import logging  # noqa: PLC0415
+
+    logger = logging.getLogger("gwmock_pop")
+
+    try:
+        input_path = input_path_arg.expanduser()
+        output_path = output.expanduser()
+        infer_population_file_format(input_path)
+        infer_population_file_format(output_path)
+        loaded_column_map = {} if column_map is None else _load_column_map(column_map.expanduser())
+        canonical_names = _canonical_parameter_names()
+        _validate_column_map_targets(loaded_column_map, canonical_names)
+        raw_catalogue = read_population_catalogue(input_path)
+        converted, renamed_columns, skipped_columns = _filter_canonical_columns(
+            raw_catalogue=raw_catalogue,
+            column_map=loaded_column_map,
+            canonical_names=canonical_names,
+        )
+    except Exception as error:
+        logger.error("%s", error)
+        raise typer.Exit(1) from error
+
+    if not converted:
+        logger.error("No canonical gwmock-pop columns remain after applying the optional column map.")
+        raise typer.Exit(1)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        logger.error("Refusing to overwrite existing output file %s.", output_path)
+        raise typer.Exit(1)
+
+    try:
+        write_population_catalogue(output_path=output_path, population=converted)
+    except Exception as error:
+        logger.error("%s", error)
+        raise typer.Exit(1) from error
+
+    typer.echo(
+        _render_conversion_summary(
+            output_path=output_path,
+            population=converted,
+            renamed_columns=renamed_columns,
+            skipped_columns=skipped_columns,
+        )
+    )

--- a/src/gwmock_pop/cli/main.py
+++ b/src/gwmock_pop/cli/main.py
@@ -94,11 +94,13 @@ def main(
 
 def register_commands() -> None:
     """Register CLI commands."""
+    from gwmock_pop.cli.convert import convert_command  # noqa: PLC0415
     from gwmock_pop.cli.inspect import inspect_command  # noqa: PLC0415
     from gwmock_pop.cli.list import list_command  # noqa: PLC0415
     from gwmock_pop.cli.simulate import simulate_command  # noqa: PLC0415
     from gwmock_pop.cli.validate import validate_command  # noqa: PLC0415
 
+    app.command("convert", help="Convert named-column population catalogues.")(convert_command)
     app.command("inspect", help="Inspect populations with quick summary statistics.")(inspect_command)
     app.command("list", help="List packaged presets and public simulator classes.")(list_command)
     app.command("simulate", help="Simulate populations.")(simulate_command)

--- a/src/gwmock_pop/cli/simulate.py
+++ b/src/gwmock_pop/cli/simulate.py
@@ -2,90 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Annotated
 
-import h5py
-import numpy as np
 import typer
-from jax import Array
 
 from gwmock_pop.cli.common import resolve_simulator
-
-_HDF5_DATASET_NAME = "data"
-_SUPPORTED_OUTPUT_SUFFIXES = {".csv": "csv", ".hdf5": "hdf5", ".h5": "hdf5"}
-
-
-def _infer_output_format(output_path: Path) -> str:
-    """Infer the persistence format from the output file suffix."""
-    file_format = _SUPPORTED_OUTPUT_SUFFIXES.get(output_path.suffix.lower())
-    if file_format is None:
-        supported = ", ".join(sorted(_SUPPORTED_OUTPUT_SUFFIXES))
-        raise ValueError(f"Unsupported output format for {output_path}. Supported suffixes: {supported}.")
-    return file_format
-
-
-def _population_columns(population: Mapping[str, Array]) -> list[str]:
-    """Return the stable output column ordering for a sampled population."""
-    return list(population)
-
-
-def _population_size(population: Mapping[str, Array], columns: Sequence[str]) -> int:
-    """Return the number of sampled rows in the population."""
-    if not columns:
-        return 0
-    return int(np.asarray(population[columns[0]]).shape[0])
-
-
-def _population_matrix(population: Mapping[str, Array], columns: Sequence[str], n_rows: int) -> np.ndarray:
-    """Materialize the sampled population as a dense 2-D matrix."""
-    matrix = np.empty((n_rows, len(columns)), dtype=float)
-    for column_index, column_name in enumerate(columns):
-        matrix[:, column_index] = np.asarray(population[column_name], dtype=float)
-    return matrix
-
-
-def _population_structured_array(population: Mapping[str, Array], columns: Sequence[str], n_rows: int) -> np.ndarray:
-    """Materialize the sampled population as a structured array with named columns."""
-    dtype = [(column_name, np.asarray(population[column_name]).dtype) for column_name in columns]
-    structured = np.empty(n_rows, dtype=dtype)
-    for column_name in columns:
-        structured[column_name] = np.asarray(population[column_name])
-    return structured
-
-
-def _write_population_csv(
-    output_path: Path, population: Mapping[str, Array], columns: Sequence[str], n_rows: int
-) -> None:
-    """Persist a population as a header-based CSV file."""
-    matrix = _population_matrix(population=population, columns=columns, n_rows=n_rows)
-    np.savetxt(output_path, matrix, delimiter=",", header=",".join(columns), comments="")
-
-
-def _write_population_hdf5(
-    output_path: Path, population: Mapping[str, Array], columns: Sequence[str], n_rows: int
-) -> None:
-    """Persist a population as a structured HDF5 dataset named ``data``."""
-    structured = _population_structured_array(population=population, columns=columns, n_rows=n_rows)
-    with h5py.File(output_path, "w") as handle:
-        handle.create_dataset(_HDF5_DATASET_NAME, data=structured)
-
-
-def _write_population(output_path: Path, population: Mapping[str, Array]) -> None:
-    """Persist a sampled population using named-column conventions."""
-    columns = _population_columns(population)
-    n_rows = _population_size(population=population, columns=columns)
-    file_format = _infer_output_format(output_path)
-
-    if file_format == "csv":
-        _write_population_csv(output_path=output_path, population=population, columns=columns, n_rows=n_rows)
-        return
-    if file_format == "hdf5":
-        _write_population_hdf5(output_path=output_path, population=population, columns=columns, n_rows=n_rows)
-        return
-
-    raise ValueError(f"Unsupported output format {file_format!r}.")
+from gwmock_pop.loaders.file_loader import infer_population_file_format, write_population_catalogue
 
 
 def simulate_command(
@@ -102,7 +25,7 @@ def simulate_command(
     try:
         simulator = resolve_simulator(config=config, seed=seed)
         output_path = output.expanduser()
-        _infer_output_format(output_path)
+        infer_population_file_format(output_path)
     except Exception as error:
         logger.error("%s", error)
         raise typer.Exit(1) from error
@@ -114,7 +37,7 @@ def simulate_command(
 
     try:
         population = simulator.simulate(n)
-        _write_population(output_path=output_path, population=population)
+        write_population_catalogue(output_path=output_path, population=population)
     except Exception as error:
         logger.error("%s", error)
         raise typer.Exit(1) from error

--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +12,102 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+
+_HDF5_DATASET_NAME = "data"
+_SUPPORTED_CATALOGUE_SUFFIXES = {".csv": "csv", ".hdf5": "hdf5", ".h5": "hdf5"}
+
+
+def infer_population_file_format(path: str | os.PathLike) -> str:
+    """Infer the file format for a population catalogue path."""
+    output_path = Path(path)
+    file_format = _SUPPORTED_CATALOGUE_SUFFIXES.get(output_path.suffix.lower())
+    if file_format is None:
+        supported = ", ".join(sorted(_SUPPORTED_CATALOGUE_SUFFIXES))
+        raise ValueError(f"Unsupported population-file format for {output_path}. Supported suffixes: {supported}.")
+    return file_format
+
+
+def apply_population_column_map(
+    catalogue: Mapping[str, np.ndarray], column_map: Mapping[str, str] | None = None
+) -> dict[str, np.ndarray]:
+    """Apply a deterministic column-renaming map to a catalogue mapping."""
+    return FilePopulationLoader._apply_column_map(dict(catalogue), dict(column_map or {}))
+
+
+def read_population_catalogue(
+    path: str | os.PathLike,
+    *,
+    column_map: Mapping[str, str] | None = None,
+    hdf5_dataset: str = _HDF5_DATASET_NAME,
+) -> dict[str, np.ndarray]:
+    """Read a named-column population catalogue from disk."""
+    catalogue = FilePopulationLoader._read_catalogue(Path(path), hdf5_dataset=hdf5_dataset)
+    return apply_population_column_map(catalogue, column_map)
+
+
+def _population_columns(population: Mapping[str, Array | np.ndarray]) -> list[str]:
+    """Return the stable output column ordering for a population mapping."""
+    return list(population)
+
+
+def _population_size(population: Mapping[str, Array | np.ndarray], columns: Sequence[str]) -> int:
+    """Return the number of rows in a population mapping."""
+    if not columns:
+        return 0
+    return int(np.asarray(population[columns[0]]).shape[0])
+
+
+def _population_matrix(population: Mapping[str, Array | np.ndarray], columns: Sequence[str], n_rows: int) -> np.ndarray:
+    """Materialize a population mapping as a dense 2-D matrix."""
+    matrix = np.empty((n_rows, len(columns)), dtype=float)
+    for column_index, column_name in enumerate(columns):
+        matrix[:, column_index] = np.asarray(population[column_name], dtype=float)
+    return matrix
+
+
+def _population_structured_array(
+    population: Mapping[str, Array | np.ndarray], columns: Sequence[str], n_rows: int
+) -> np.ndarray:
+    """Materialize a population mapping as a structured array with named columns."""
+    dtype = [(column_name, np.asarray(population[column_name]).dtype) for column_name in columns]
+    structured = np.empty(n_rows, dtype=dtype)
+    for column_name in columns:
+        structured[column_name] = np.asarray(population[column_name])
+    return structured
+
+
+def _write_population_csv(
+    output_path: Path, population: Mapping[str, Array | np.ndarray], columns: Sequence[str], n_rows: int
+) -> None:
+    """Persist a population as a header-based CSV file."""
+    matrix = _population_matrix(population=population, columns=columns, n_rows=n_rows)
+    np.savetxt(output_path, matrix, delimiter=",", header=",".join(columns), comments="")
+
+
+def _write_population_hdf5(
+    output_path: Path, population: Mapping[str, Array | np.ndarray], columns: Sequence[str], n_rows: int
+) -> None:
+    """Persist a population as a structured HDF5 dataset named ``data``."""
+    structured = _population_structured_array(population=population, columns=columns, n_rows=n_rows)
+    with h5py.File(output_path, "w") as handle:
+        handle.create_dataset(_HDF5_DATASET_NAME, data=structured)
+
+
+def write_population_catalogue(output_path: str | os.PathLike, population: Mapping[str, Array | np.ndarray]) -> None:
+    """Persist a population mapping using named-column CSV/HDF5 conventions."""
+    destination = Path(output_path)
+    columns = _population_columns(population)
+    n_rows = _population_size(population=population, columns=columns)
+    file_format = infer_population_file_format(destination)
+
+    if file_format == "csv":
+        _write_population_csv(output_path=destination, population=population, columns=columns, n_rows=n_rows)
+        return
+    if file_format == "hdf5":
+        _write_population_hdf5(output_path=destination, population=population, columns=columns, n_rows=n_rows)
+        return
+
+    raise ValueError(f"Unsupported format {file_format!r}.")
 
 
 class FilePopulationLoader:
@@ -32,7 +128,7 @@ class FilePopulationLoader:
         path: str | os.PathLike,
         *,
         column_map: dict[str, str] | None = None,
-        hdf5_dataset: str = "data",
+        hdf5_dataset: str = _HDF5_DATASET_NAME,
     ) -> None:
         """Load and validate a population catalogue from disk.
 
@@ -57,8 +153,8 @@ class FilePopulationLoader:
         self._source_type = source_type
         self._path = Path(path)
 
-        catalogue = self._read_catalogue(self._path, hdf5_dataset=hdf5_dataset)
-        self._catalogue = self._apply_column_map(catalogue, column_map or {})
+        raw_catalogue = read_population_catalogue(self._path, column_map=column_map or {}, hdf5_dataset=hdf5_dataset)
+        self._catalogue = {name: jnp.asarray(values) for name, values in raw_catalogue.items()}
 
         if not self._catalogue:
             raise ValueError("Loaded catalogue is empty.")
@@ -111,18 +207,18 @@ class FilePopulationLoader:
         return {name: self._catalogue[name][indices] for name in self._parameter_names}
 
     @staticmethod
-    def _read_catalogue(path: Path, *, hdf5_dataset: str) -> dict[str, Array]:
+    def _read_catalogue(path: Path, *, hdf5_dataset: str) -> dict[str, np.ndarray]:
         """Read a named-column catalogue from an HDF5 or CSV file."""
-        suffix = path.suffix.lower()
-        if suffix in {".hdf5", ".h5"}:
+        file_format = infer_population_file_format(path)
+        if file_format == "hdf5":
             return FilePopulationLoader._read_hdf5_catalogue(path, dataset_name=hdf5_dataset)
-        if suffix == ".csv":
+        if file_format == "csv":
             return FilePopulationLoader._read_csv_catalogue(path)
 
-        raise ValueError("Unsupported file format. Supported formats are: .hdf5, .h5, .csv.")
+        raise ValueError(f"Unsupported format {file_format!r}.")
 
     @staticmethod
-    def _read_hdf5_catalogue(path: Path, *, dataset_name: str) -> dict[str, Array]:
+    def _read_hdf5_catalogue(path: Path, *, dataset_name: str) -> dict[str, np.ndarray]:
         """Read an HDF5 catalogue from a compound dataset or group-of-datasets."""
         with h5py.File(path, "r") as handle:
             hdf5_object = handle[dataset_name]
@@ -151,7 +247,7 @@ class FilePopulationLoader:
             raise ValueError(f"HDF5 object '{dataset_name}' must be a dataset or a group of datasets.")
 
     @staticmethod
-    def _read_csv_catalogue(path: Path) -> dict[str, Array]:
+    def _read_csv_catalogue(path: Path) -> dict[str, np.ndarray]:
         """Read a header-based CSV file into a catalogue mapping."""
         data = np.genfromtxt(path, delimiter=",", names=True, dtype=None, encoding=None)
         data = np.atleast_1d(data)
@@ -159,16 +255,16 @@ class FilePopulationLoader:
 
     @staticmethod
     def _structured_array_to_catalogue(
-        data: np.ndarray | Mapping[str, np.ndarray | Array], *, file_format: str
-    ) -> dict[str, Array]:
-        """Convert named-column data into a catalogue mapping of 1-D JAX arrays."""
+        data: np.ndarray | Mapping[str, np.ndarray], *, file_format: str
+    ) -> dict[str, np.ndarray]:
+        """Convert named-column data into a catalogue mapping of 1-D numpy arrays."""
         if isinstance(data, Mapping):
-            catalogue = {name: jnp.asarray(np.atleast_1d(values)) for name, values in data.items()}
+            catalogue = {name: np.atleast_1d(np.asarray(values)) for name, values in data.items()}
         else:
             column_names = data.dtype.names
             if column_names is None:
                 raise ValueError(f"{file_format} catalogue must provide named columns.")
-            catalogue = {name: jnp.asarray(np.atleast_1d(data[name])) for name in column_names}
+            catalogue = {name: np.atleast_1d(np.asarray(data[name])) for name in column_names}
 
         if not catalogue:
             raise ValueError(f"{file_format} catalogue is empty.")
@@ -177,7 +273,7 @@ class FilePopulationLoader:
         return catalogue
 
     @staticmethod
-    def _apply_column_map(catalogue: dict[str, Array], column_map: dict[str, str]) -> dict[str, Array]:
+    def _apply_column_map(catalogue: dict[str, np.ndarray], column_map: dict[str, str]) -> dict[str, np.ndarray]:
         """Apply a deterministic column renaming map to a catalogue mapping."""
         unknown_columns = sorted(set(column_map) - set(catalogue))
         if unknown_columns:

--- a/tests/cli/test_cli_convert.py
+++ b/tests/cli/test_cli_convert.py
@@ -1,0 +1,96 @@
+"""Tests for the CLI convert command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+from typer.testing import CliRunner
+
+from gwmock_pop.cli.main import app
+
+_RUNNER = CliRunner()
+
+
+def _write_hdf5_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
+    """Write a structured HDF5 dataset with named columns."""
+    dtype = [(name, np.float64) for name in columns]
+    structured = np.zeros(len(next(iter(columns.values()))), dtype=dtype)
+    for name, values in columns.items():
+        structured[name] = values
+
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset("data", data=structured)
+
+
+def _write_csv_catalogue(path: Path, columns: dict[str, np.ndarray]) -> None:
+    """Write a header-based CSV file with named columns."""
+    matrix = np.column_stack([columns[name] for name in columns])
+    np.savetxt(path, matrix, delimiter=",", header=",".join(columns), comments="")
+
+
+def test_convert_command_converts_hdf5_to_csv_losslessly(tmp_path: Path) -> None:
+    """The convert CLI preserves canonical floating-point columns across HDF5 -> CSV."""
+    input_path = tmp_path / "population.hdf5"
+    output_path = tmp_path / "population.csv"
+    columns = {
+        "detector_frame_mass_1": np.linspace(10.0, 20.0, 8),
+        "detector_frame_mass_2": np.linspace(5.0, 15.0, 8),
+        "redshift": np.linspace(0.01, 0.2, 8),
+    }
+    _write_hdf5_catalogue(input_path, columns)
+
+    result = _RUNNER.invoke(app, ["convert", "--input", str(input_path), "--output", str(output_path)])
+
+    assert result.exit_code == 0, result.output
+    assert "Renamed columns: none" in result.output
+    assert "Skipped columns: none" in result.output
+
+    reloaded = np.genfromtxt(output_path, delimiter=",", names=True, dtype=float)
+    assert reloaded.dtype.names == tuple(columns)
+    for name, values in columns.items():
+        np.testing.assert_allclose(np.asarray(reloaded[name]), values, rtol=0.0, atol=0.0)
+
+
+def test_convert_command_applies_column_map_and_reports_skipped_columns(tmp_path: Path) -> None:
+    """The convert CLI remaps external names and drops columns without canonical targets."""
+    input_path = tmp_path / "external.csv"
+    output_path = tmp_path / "canonical.hdf5"
+    map_path = tmp_path / "map.json"
+    columns = {
+        "m1": np.linspace(30.0, 60.0, 6),
+        "m2": np.linspace(20.0, 40.0, 6),
+        "z": np.linspace(0.05, 0.5, 6),
+        "external_weight": np.linspace(1.0, 2.0, 6),
+    }
+    _write_csv_catalogue(input_path, columns)
+    map_path.write_text(
+        json.dumps(
+            {
+                "m1": "detector_frame_mass_1",
+                "m2": "detector_frame_mass_2",
+                "z": "redshift",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = _RUNNER.invoke(
+        app,
+        ["convert", "--input", str(input_path), "--output", str(output_path), "--column-map", str(map_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "m1 -> detector_frame_mass_1" in result.output
+    assert "m2 -> detector_frame_mass_2" in result.output
+    assert "z -> redshift" in result.output
+    assert "Skipped columns: external_weight" in result.output
+
+    with h5py.File(output_path, "r") as handle:
+        dataset = handle["data"]
+        assert dataset.dtype.names == ("detector_frame_mass_1", "detector_frame_mass_2", "redshift")
+        np.testing.assert_allclose(np.asarray(dataset["detector_frame_mass_1"]), columns["m1"], rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(np.asarray(dataset["detector_frame_mass_2"]), columns["m2"], rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(np.asarray(dataset["redshift"]), columns["z"], rtol=0.0, atol=0.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `convert` CLI command to transform population catalogues between CSV and HDF5 formats.
  * Support for optional column mapping via JSON/YAML configuration files during conversion.
  * Conversion includes validation of file paths, column filtering, and a summary report of the operation (row count, retained columns, and skipped columns).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->