### PR TITLE
feat: Add a set of named preset YAML configs as package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ source = "uv-dynamic-versioning"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gwmock_pop"]
+include = ["src/gwmock_pop/configs/*.yaml"]
 
 [tool.bandit]
 exclude_dirs = ["build", "dist", "tests", "scripts"]

--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from gwmock_pop.configs import list_presets
 from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
@@ -27,4 +28,5 @@ __all__ = [
     "NSBHPriorSimulator",
     "PoissonEventSampler",
     "__version__",
+    "list_presets",
 ]

--- a/src/gwmock_pop/cli/common.py
+++ b/src/gwmock_pop/cli/common.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from gwmock_pop.protocols import GWPopSimulator
-from gwmock_pop.simulators.bbh.base import BBHSimulator
 from gwmock_pop.simulators.graph import GraphSimulator
 
 _CONFIG_FILE_SUFFIXES = {".yaml", ".yml", ".toml"}
@@ -22,7 +21,7 @@ def resolve_simulator(config: str, seed: int | None) -> GWPopSimulator:
     if config_path.exists():
         raise ValueError(f"Configuration path is not a file: {config_path}")
     try:
-        return BBHSimulator.from_preset(config, seed=seed)
+        return GraphSimulator.from_preset(config, seed=seed)
     except ValueError as error:
         if config_path.suffix.lower() in _CONFIG_FILE_SUFFIXES:
             raise FileNotFoundError(f"Configuration file does not exist: {config_path}") from error

--- a/src/gwmock_pop/configs/__init__.py
+++ b/src/gwmock_pop/configs/__init__.py
@@ -9,6 +9,9 @@ from pathlib import Path
 
 from gwmock_pop.utils.yaml import read_data_file
 
+_PRESET_ALIASES = {
+    "gwtc4": "bbh_gwtc4",
+}
 _SUPPORTED_CONFIG_SUFFIXES = {".yaml", ".yml", ".toml"}
 _REQUIRED_PRESET_FIELDS = ("name", "source_type", "description", "parameters")
 
@@ -59,15 +62,38 @@ def iter_packaged_presets() -> list[PackagedPreset]:
     return sorted(presets, key=lambda preset: preset.name)
 
 
-def get_packaged_preset_resource(preset_name: str) -> Traversable:
-    """Return the packaged config resource for a named preset."""
+def list_presets() -> list[str]:
+    """Return the public packaged preset names."""
+    return [preset.name for preset in iter_packaged_presets()]
+
+
+def _resolve_preset_name(preset_name: str) -> str:
+    """Resolve compatibility aliases to canonical packaged preset names."""
+    return _PRESET_ALIASES.get(preset_name, preset_name)
+
+
+def get_packaged_preset(preset_name: str) -> PackagedPreset:
+    """Return metadata for one named packaged preset."""
+    resolved_name = _resolve_preset_name(preset_name)
     presets = iter_packaged_presets()
     for preset in presets:
-        if preset.name == preset_name:
-            return files(__name__).joinpath(preset.resource_name)
+        if preset.name == resolved_name:
+            return preset
 
-    available = ", ".join(p.name for p in presets)
+    available = ", ".join(list_presets())
     raise ValueError(f"Unknown preset {preset_name!r}. Available presets: {available}.")
 
 
-__all__ = ["PackagedPreset", "get_packaged_preset_resource", "iter_packaged_presets"]
+def get_packaged_preset_resource(preset_name: str) -> Traversable:
+    """Return the packaged config resource for a named preset."""
+    preset = get_packaged_preset(preset_name)
+    return files(__name__).joinpath(preset.resource_name)
+
+
+__all__ = [
+    "PackagedPreset",
+    "get_packaged_preset",
+    "get_packaged_preset_resource",
+    "iter_packaged_presets",
+    "list_presets",
+]

--- a/src/gwmock_pop/configs/bbh_flat.yaml
+++ b/src/gwmock_pop/configs/bbh_flat.yaml
@@ -1,73 +1,35 @@
-name: bbh_gwtc4
+name: bbh_flat
 source_type: bbh
 description:
-    GWTC-4-inspired BBH graph preset with masses, spins, distance, and extrinsic
-    parameters.
+    Flat-in-log BBH graph preset with ordered component masses on [5, 100] solar
+    masses.
 parameters:
-    detector_frame_mass_1:
-        sampler:
-            function: planck_tapered_broken_power_law_plus_two_peaks
-            arguments:
-                alpha_1: 1.72
-                alpha_2: 4.51
-                transition: 35.6
-                minimum: 5.06
-                maximum: 300.0
-                mean_1: 9.76
-                sigma_1: 0.649
-                mean_2: 32.8
-                sigma_2: 3.92
-                taper_range: 4.32
-                lambda_0: 0.361
-                lambda_1: 0.586
-    mass_ratio:
+    raw_mass_1:
         intermediate: true
         sampler:
-            function: planck_tapered_conditional_ratio_power_law
+            function: log_uniform
             arguments:
-                denominator: '@detector_frame_mass_1'
-                beta: 1.26
-                numerator_minimum: 5.06
-                taper_range: 4.32
-                minimum: 0.0
-                maximum: 1.0
-                n_grids: 2048
+                minimum: 5.0
+                maximum: 100.0
+    raw_mass_2:
+        intermediate: true
+        sampler:
+            function: log_uniform
+            arguments:
+                minimum: 5.0
+                maximum: 100.0
+    detector_frame_mass_1:
+        transform:
+            function: maximum
+            arguments:
+                left: '@raw_mass_1'
+                right: '@raw_mass_2'
     detector_frame_mass_2:
         transform:
-            function: multiply
+            function: minimum
             arguments:
-                left: '@detector_frame_mass_1'
-                right: '@mass_ratio'
-    spin_magnitude_1:
-        intermediate: true
-        transform:
-            function: beta_spin_magnitude
-            arguments:
-                alpha: 2.0
-                beta: 6.0
-                reference: '@detector_frame_mass_1'
-                minimum: 0.0
-                maximum: 0.99
-    spin_magnitude_2:
-        intermediate: true
-        transform:
-            function: beta_spin_magnitude
-            arguments:
-                alpha: 2.0
-                beta: 6.0
-                reference: '@detector_frame_mass_1'
-                minimum: 0.0
-                maximum: 0.99
-    chi_eff:
-        intermediate: true
-        transform:
-            function: gaussian_chi_eff
-            arguments:
-                reference: '@detector_frame_mass_1'
-                mean: 0.0
-                sigma: 0.1
-                minimum: -0.5
-                maximum: 0.5
+                left: '@raw_mass_1'
+                right: '@raw_mass_2'
     spin_1x:
         transform:
             function: constant_like
@@ -82,14 +44,10 @@ parameters:
                 value: 0.0
     spin_1z:
         transform:
-            function: gaussian_chi_eff
+            function: constant_like
             arguments:
-                component: primary
-                chi_eff: '@chi_eff'
-                mass_1: '@detector_frame_mass_1'
-                mass_2: '@detector_frame_mass_2'
-                spin_magnitude_1: '@spin_magnitude_1'
-                spin_magnitude_2: '@spin_magnitude_2'
+                reference: '@detector_frame_mass_1'
+                value: 0.0
     spin_2x:
         transform:
             function: constant_like
@@ -104,14 +62,10 @@ parameters:
                 value: 0.0
     spin_2z:
         transform:
-            function: gaussian_chi_eff
+            function: constant_like
             arguments:
-                component: secondary
-                chi_eff: '@chi_eff'
-                mass_1: '@detector_frame_mass_1'
-                mass_2: '@detector_frame_mass_2'
-                spin_magnitude_1: '@spin_magnitude_1'
-                spin_magnitude_2: '@spin_magnitude_2'
+                reference: '@detector_frame_mass_1'
+                value: 0.0
     eccentricity:
         transform:
             function: constant_like

--- a/src/gwmock_pop/configs/bns_flat.yaml
+++ b/src/gwmock_pop/configs/bns_flat.yaml
@@ -1,73 +1,35 @@
-name: bbh_gwtc4
-source_type: bbh
+name: bns_flat
+source_type: bns
 description:
-    GWTC-4-inspired BBH graph preset with masses, spins, distance, and extrinsic
-    parameters.
+    Flat BNS graph preset with ordered component masses on [1.0, 3.0] solar
+    masses.
 parameters:
-    detector_frame_mass_1:
-        sampler:
-            function: planck_tapered_broken_power_law_plus_two_peaks
-            arguments:
-                alpha_1: 1.72
-                alpha_2: 4.51
-                transition: 35.6
-                minimum: 5.06
-                maximum: 300.0
-                mean_1: 9.76
-                sigma_1: 0.649
-                mean_2: 32.8
-                sigma_2: 3.92
-                taper_range: 4.32
-                lambda_0: 0.361
-                lambda_1: 0.586
-    mass_ratio:
+    raw_mass_1:
         intermediate: true
         sampler:
-            function: planck_tapered_conditional_ratio_power_law
+            function: uniform
             arguments:
-                denominator: '@detector_frame_mass_1'
-                beta: 1.26
-                numerator_minimum: 5.06
-                taper_range: 4.32
-                minimum: 0.0
-                maximum: 1.0
-                n_grids: 2048
+                minimum: 1.0
+                maximum: 3.0
+    raw_mass_2:
+        intermediate: true
+        sampler:
+            function: uniform
+            arguments:
+                minimum: 1.0
+                maximum: 3.0
+    detector_frame_mass_1:
+        transform:
+            function: maximum
+            arguments:
+                left: '@raw_mass_1'
+                right: '@raw_mass_2'
     detector_frame_mass_2:
         transform:
-            function: multiply
+            function: minimum
             arguments:
-                left: '@detector_frame_mass_1'
-                right: '@mass_ratio'
-    spin_magnitude_1:
-        intermediate: true
-        transform:
-            function: beta_spin_magnitude
-            arguments:
-                alpha: 2.0
-                beta: 6.0
-                reference: '@detector_frame_mass_1'
-                minimum: 0.0
-                maximum: 0.99
-    spin_magnitude_2:
-        intermediate: true
-        transform:
-            function: beta_spin_magnitude
-            arguments:
-                alpha: 2.0
-                beta: 6.0
-                reference: '@detector_frame_mass_1'
-                minimum: 0.0
-                maximum: 0.99
-    chi_eff:
-        intermediate: true
-        transform:
-            function: gaussian_chi_eff
-            arguments:
-                reference: '@detector_frame_mass_1'
-                mean: 0.0
-                sigma: 0.1
-                minimum: -0.5
-                maximum: 0.5
+                left: '@raw_mass_1'
+                right: '@raw_mass_2'
     spin_1x:
         transform:
             function: constant_like
@@ -82,14 +44,10 @@ parameters:
                 value: 0.0
     spin_1z:
         transform:
-            function: gaussian_chi_eff
+            function: constant_like
             arguments:
-                component: primary
-                chi_eff: '@chi_eff'
-                mass_1: '@detector_frame_mass_1'
-                mass_2: '@detector_frame_mass_2'
-                spin_magnitude_1: '@spin_magnitude_1'
-                spin_magnitude_2: '@spin_magnitude_2'
+                reference: '@detector_frame_mass_1'
+                value: 0.0
     spin_2x:
         transform:
             function: constant_like
@@ -104,14 +62,10 @@ parameters:
                 value: 0.0
     spin_2z:
         transform:
-            function: gaussian_chi_eff
+            function: constant_like
             arguments:
-                component: secondary
-                chi_eff: '@chi_eff'
-                mass_1: '@detector_frame_mass_1'
-                mass_2: '@detector_frame_mass_2'
-                spin_magnitude_1: '@spin_magnitude_1'
-                spin_magnitude_2: '@spin_magnitude_2'
+                reference: '@detector_frame_mass_1'
+                value: 0.0
     eccentricity:
         transform:
             function: constant_like
@@ -122,7 +76,7 @@ parameters:
         sampler:
             function: uniform_comoving_volume_distance
             arguments:
-                d_max: 10000.0
+                d_max: 5000.0
     coa_phase:
         transform:
             function: constant_like

--- a/src/gwmock_pop/samplers/__init__.py
+++ b/src/gwmock_pop/samplers/__init__.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+from gwmock_pop.samplers.log_uniform import log_uniform
 from gwmock_pop.samplers.mass_ratio_pairing import mass_ratio_pairing
 from gwmock_pop.samplers.planck_tapered_broken_power_law_plus_two_peaks import (
     planck_tapered_broken_power_law_plus_two_peaks,
 )
 from gwmock_pop.samplers.planck_tapered_conditional_ratio_power_law import planck_tapered_conditional_ratio_power_law
 from gwmock_pop.samplers.power_law_plus_peak import power_law_plus_peak
+from gwmock_pop.samplers.uniform import uniform
 from gwmock_pop.samplers.uniform_comoving_volume_distance import uniform_comoving_volume_distance
 
 __all__ = [
+    "log_uniform",
     "mass_ratio_pairing",
     "planck_tapered_broken_power_law_plus_two_peaks",
     "planck_tapered_conditional_ratio_power_law",
     "power_law_plus_peak",
+    "uniform",
     "uniform_comoving_volume_distance",
 ]

--- a/src/gwmock_pop/samplers/log_uniform.py
+++ b/src/gwmock_pop/samplers/log_uniform.py
@@ -1,0 +1,25 @@
+"""Log-uniform sampler utilities for graph presets."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+from jax import Array
+
+
+def log_uniform(*, key: Array, n_samples: int, minimum: float, maximum: float) -> Array:
+    """Draw samples uniformly in log-space on ``[minimum, maximum]``."""
+    if n_samples < 0:
+        raise ValueError(f"n_samples must be >= 0, got {n_samples}.")
+    if minimum <= 0.0:
+        raise ValueError(f"minimum must be > 0 for log-uniform sampling, got {minimum}.")
+    if maximum <= minimum:
+        raise ValueError(f"maximum must be > minimum, got {maximum} <= {minimum}.")
+
+    log_samples = jax.random.uniform(
+        key,
+        shape=(n_samples,),
+        minval=jnp.log(minimum),
+        maxval=jnp.log(maximum),
+    )
+    return jnp.exp(log_samples)

--- a/src/gwmock_pop/samplers/uniform.py
+++ b/src/gwmock_pop/samplers/uniform.py
@@ -1,0 +1,15 @@
+"""Uniform sampler utilities for graph presets."""
+
+from __future__ import annotations
+
+import jax
+from jax import Array
+
+
+def uniform(*, key: Array, n_samples: int, minimum: float, maximum: float) -> Array:
+    """Draw samples uniformly on ``[minimum, maximum]``."""
+    if n_samples < 0:
+        raise ValueError(f"n_samples must be >= 0, got {n_samples}.")
+    if maximum < minimum:
+        raise ValueError(f"maximum must be >= minimum, got {maximum} < {minimum}.")
+    return jax.random.uniform(key, shape=(n_samples,), minval=minimum, maxval=maximum)

--- a/src/gwmock_pop/simulators/bbh/base.py
+++ b/src/gwmock_pop/simulators/bbh/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.resources import as_file
 from typing import Any
 
-from gwmock_pop.configs import get_packaged_preset_resource
+from gwmock_pop.configs import get_packaged_preset, get_packaged_preset_resource
 from gwmock_pop.mixins.random import RandomMixin
 from gwmock_pop.simulators.graph import GraphSimulator
 from gwmock_pop.simulators.simulator import Simulator
@@ -37,8 +37,15 @@ class BBHSimulator(RandomMixin, Simulator):
         """
         del cls
 
+        preset = get_packaged_preset(preset_name)
+        if preset.source_type != "bbh":
+            raise ValueError(
+                f"Preset {preset_name!r} has source_type {preset.source_type!r}; "
+                "BBHSimulator.from_preset() only supports BBH presets."
+            )
+
         options = dict(kwargs)
-        options.setdefault("source_type", "bbh")
+        options.setdefault("source_type", preset.source_type)
         with as_file(get_packaged_preset_resource(preset_name)) as config_path:
             return GraphSimulator.from_config_file(config_path, **options)
 

--- a/src/gwmock_pop/simulators/graph.py
+++ b/src/gwmock_pop/simulators/graph.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import secrets
+from importlib.resources import as_file
 from pathlib import Path
 from typing import Any
 
@@ -12,6 +13,7 @@ import jax.numpy as jnp
 import networkx as nx
 from jax import Array
 
+from gwmock_pop.configs import get_packaged_preset, get_packaged_preset_resource
 from gwmock_pop.graph.build import build_dependency_graph
 from gwmock_pop.mixins.random import RandomMixin
 from gwmock_pop.simulators.simulator import Simulator
@@ -320,6 +322,15 @@ class GraphSimulator(RandomMixin, Simulator):
             config = config["parameters"]
 
         return cls(config=config, **kwargs)
+
+    @classmethod
+    def from_preset(cls, preset_name: str, **kwargs: Any) -> GraphSimulator:
+        """Create a graph simulator from a packaged preset."""
+        preset = get_packaged_preset(preset_name)
+        options = dict(kwargs)
+        options.setdefault("source_type", preset.source_type)
+        with as_file(get_packaged_preset_resource(preset_name)) as config_path:
+            return cls.from_config_file(config_path, **options)
 
     def reset(self) -> None:
         """Reset the simulator state."""

--- a/src/gwmock_pop/transforms/__init__.py
+++ b/src/gwmock_pop/transforms/__init__.py
@@ -8,6 +8,8 @@ from gwmock_pop.transforms.basic import (
     gaussian_chi_eff,
     isotropic_spin_orientation,
     luminosity_distance_to_redshift,
+    maximum,
+    minimum,
     multiply,
 )
 
@@ -17,5 +19,7 @@ __all__ = [
     "gaussian_chi_eff",
     "isotropic_spin_orientation",
     "luminosity_distance_to_redshift",
+    "maximum",
+    "minimum",
     "multiply",
 ]

--- a/src/gwmock_pop/transforms/basic.py
+++ b/src/gwmock_pop/transforms/basic.py
@@ -57,6 +57,16 @@ def multiply(left: Array, right: Array) -> Array:
     return jnp.asarray(left) * jnp.asarray(right)
 
 
+def maximum(left: Array, right: Array) -> Array:
+    """Return the elementwise maximum of two array-like inputs."""
+    return jnp.maximum(jnp.asarray(left), jnp.asarray(right))
+
+
+def minimum(left: Array, right: Array) -> Array:
+    """Return the elementwise minimum of two array-like inputs."""
+    return jnp.minimum(jnp.asarray(left), jnp.asarray(right))
+
+
 def isotropic_spin_orientation(*, key: Array, reference: Array | None = None, n_samples: int | None = None) -> Array:
     """Draw polar angles with ``cos(tilt)`` uniform on ``[-1, 1]``."""
     shape = _resolve_output_shape(reference=reference, n_samples=n_samples)

--- a/tests/cli/test_cli_list.py
+++ b/tests/cli/test_cli_list.py
@@ -18,9 +18,13 @@ def test_list_command_prints_packaged_presets_and_public_simulator_classes() -> 
     assert "Name" in result.output
     assert "Source type" in result.output
     assert "Description" in result.output
-    assert "gwtc4" in result.output
+    assert "bbh_gwtc4" in result.output
+    assert "bbh_flat" in result.output
+    assert "bns_flat" in result.output
     assert "power_law_plus_peak" in result.output
     assert "GWTC-4-inspired BBH graph preset" in result.output
+    assert "Flat-in-log BBH graph preset" in result.output
+    assert "Flat BNS graph preset" in result.output
     assert "Talbot-Thrane-inspired BBH mass graph preset" in result.output
     assert "Simulator classes" in result.output
     assert "BBHSimulator" in result.output

--- a/tests/cli/test_cli_simulate.py
+++ b/tests/cli/test_cli_simulate.py
@@ -83,6 +83,29 @@ def test_simulate_command_writes_hdf5_from_packaged_preset(tmp_path: Path) -> No
         assert set(dataset.dtype.names or ()) == _EXPECTED_BBH_COLUMNS
 
 
+def test_simulate_command_writes_hdf5_from_bns_packaged_preset(tmp_path: Path) -> None:
+    """The CLI samples the packaged BNS flat preset into a named-column HDF5 file."""
+    output_path = tmp_path / "bns_population.hdf5"
+
+    result = _RUNNER.invoke(
+        app,
+        ["simulate", "--config", "bns_flat", "--n", "64", "--output", str(output_path), "--seed", "42"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_path.exists()
+
+    with h5py.File(output_path, "r") as handle:
+        dataset = handle["data"]
+        assert dataset.shape == (64,)
+        assert set(dataset.dtype.names or ()) == _EXPECTED_BBH_COLUMNS
+        assert np.all(dataset["detector_frame_mass_1"] >= dataset["detector_frame_mass_2"])
+        assert np.all(dataset["detector_frame_mass_1"] >= 1.0)
+        assert np.all(dataset["detector_frame_mass_2"] >= 1.0)
+        assert np.all(dataset["detector_frame_mass_1"] <= 3.0)
+        assert np.all(dataset["detector_frame_mass_2"] <= 3.0)
+
+
 def test_simulate_command_writes_csv_from_config_file(tmp_path: Path) -> None:
     """The CLI samples a graph config file into a header-based CSV file."""
     config_path = tmp_path / "config.yaml"

--- a/tests/simulators/bbh/test_simulators_bbh_preset.py
+++ b/tests/simulators/bbh/test_simulators_bbh_preset.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable
+from importlib.resources import files
 
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import gwmock_pop
 from gwmock_pop.distributions import power_law_plus_peak_cdf
 from gwmock_pop.protocols import GWPopSimulator
 from gwmock_pop.simulators.bbh.base import BBHSimulator
+from gwmock_pop.simulators.graph import GraphSimulator
 
 _PRESET_HYPERPARAMETERS = {
     "alpha": 2.63,
@@ -22,6 +25,30 @@ _PRESET_HYPERPARAMETERS = {
     "peak_sigma": 5.69,
     "peak_maximum": 100.0,
 }
+
+_CANONICAL_PARAMETER_NAMES = [
+    "detector_frame_mass_1",
+    "detector_frame_mass_2",
+    "spin_1x",
+    "spin_1y",
+    "spin_1z",
+    "spin_2x",
+    "spin_2y",
+    "spin_2z",
+    "eccentricity",
+    "distance",
+    "coa_phase",
+    "inclination",
+    "theta_jn",
+    "long_asc_node",
+    "mean_per_ano",
+    "coa_time",
+    "right_ascension",
+    "declination",
+    "polarization_angle",
+    "redshift",
+    "f_ref",
+]
 
 
 def _ks_p_value(samples: np.ndarray, cdf: Callable[[np.ndarray], np.ndarray]) -> float:
@@ -55,9 +82,10 @@ def test_from_preset_returns_protocol_conformant_simulator() -> None:
     assert bool(jnp.all(result["detector_frame_mass_2"] <= result["detector_frame_mass_1"]))
 
 
-def test_gwtc4_preset_returns_canonical_bbh_surface() -> None:
-    """The GWTC4 preset exposes the full canonical BBH parameter set."""
-    simulator = BBHSimulator.from_preset("gwtc4", seed=42)
+@pytest.mark.parametrize("preset_name", ["bbh_gwtc4", "bbh_flat"])
+def test_named_bbh_presets_return_canonical_bbh_surface(preset_name: str) -> None:
+    """Named BBH presets expose the full canonical BBH parameter set."""
+    simulator = BBHSimulator.from_preset(preset_name, seed=42)
 
     result = simulator.simulate(64)
 
@@ -65,38 +93,69 @@ def test_gwtc4_preset_returns_canonical_bbh_surface() -> None:
     assert simulator.source_type == "bbh"
     assert list(result.keys()) == list(simulator.parameter_names)
     assert len(result) == 21
-    assert list(result.keys()) == [
-        "detector_frame_mass_1",
-        "detector_frame_mass_2",
-        "spin_1x",
-        "spin_1y",
-        "spin_1z",
-        "spin_2x",
-        "spin_2y",
-        "spin_2z",
-        "eccentricity",
-        "distance",
-        "coa_phase",
-        "inclination",
-        "theta_jn",
-        "long_asc_node",
-        "mean_per_ano",
-        "coa_time",
-        "right_ascension",
-        "declination",
-        "polarization_angle",
-        "redshift",
-        "f_ref",
-    ]
+    assert list(result.keys()) == _CANONICAL_PARAMETER_NAMES
     assert all(array.shape == (64,) for array in result.values())
     assert bool(jnp.all(jnp.isfinite(result["distance"])))
     assert bool(jnp.all(jnp.isfinite(result["redshift"])))
+    assert bool(jnp.all(result["detector_frame_mass_1"] >= result["detector_frame_mass_2"]))
+
+
+def test_gwtc4_alias_still_loads_canonical_bbh_preset() -> None:
+    """The legacy gwtc4 preset name remains available as a compatibility alias."""
+    alias_simulator = BBHSimulator.from_preset("gwtc4", seed=42)
+    canonical_simulator = BBHSimulator.from_preset("bbh_gwtc4", seed=42)
+
+    alias_result = alias_simulator.simulate(16)
+    canonical_result = canonical_simulator.simulate(16)
+
+    assert alias_simulator.source_type == "bbh"
+    assert list(alias_result.keys()) == _CANONICAL_PARAMETER_NAMES
+    assert list(canonical_result.keys()) == _CANONICAL_PARAMETER_NAMES
+    for parameter_name in _CANONICAL_PARAMETER_NAMES:
+        np.testing.assert_allclose(
+            np.asarray(alias_result[parameter_name]), np.asarray(canonical_result[parameter_name])
+        )
+
+
+def test_bns_flat_preset_loads_as_graph_simulator() -> None:
+    """The BNS flat preset is available through the generic graph preset loader."""
+    simulator = GraphSimulator.from_preset("bns_flat", seed=42)
+    result = simulator.simulate(64)
+
+    assert isinstance(simulator, GWPopSimulator)
+    assert simulator.source_type == "bns"
+    assert list(result.keys()) == _CANONICAL_PARAMETER_NAMES
+    assert all(array.shape == (64,) for array in result.values())
+    assert bool(jnp.all(result["detector_frame_mass_1"] >= result["detector_frame_mass_2"]))
+    assert bool(jnp.all(result["detector_frame_mass_1"] >= 1.0))
+    assert bool(jnp.all(result["detector_frame_mass_2"] >= 1.0))
+    assert bool(jnp.all(result["detector_frame_mass_1"] <= 3.0))
+    assert bool(jnp.all(result["detector_frame_mass_2"] <= 3.0))
 
 
 def test_from_preset_rejects_unknown_preset_name() -> None:
     """Unknown preset names raise a helpful error."""
     with pytest.raises(ValueError, match="Unknown preset"):
         BBHSimulator.from_preset("does_not_exist")
+
+
+def test_list_presets_returns_expected_packaged_names() -> None:
+    """Top-level preset discovery returns the expected canonical preset names."""
+    preset_names = gwmock_pop.list_presets()
+
+    assert "bbh_gwtc4" in preset_names
+    assert "bbh_flat" in preset_names
+    assert "bns_flat" in preset_names
+    assert "power_law_plus_peak" in preset_names
+
+
+def test_packaged_preset_resources_are_available_via_importlib_resources() -> None:
+    """Built-in preset config files are exposed as package resources."""
+    resource_names = {resource.name for resource in files("gwmock_pop.configs").iterdir()}
+
+    assert "bbh_gwtc4.yaml" in resource_names
+    assert "bbh_flat.yaml" in resource_names
+    assert "bns_flat.yaml" in resource_names
 
 
 def test_power_law_plus_peak_preset_passes_primary_mass_ks_check() -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preset aliasing—the `gwtc4` preset is now `bbh_gwtc4` with backward compatibility.
  * Introduced new flat-prior presets for BBH and BNS simulations.
  * Added ability to list all available packaged presets.
  * New log-uniform sampler for prior distributions.
  * Added min/max element-wise transforms for parameter transformations.

* **Tests**
  * Enhanced preset configuration validation and cross-compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->