### PR TITLE
chore: Export CBC_PARAMETER_NAMES from gwmock_pop containing all 21 anonical parameter names, making it importable for downstream validation and cross-package contract tests

### DIFF
--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from gwmock_pop.configs import list_presets
+from gwmock_pop.constants import CBC_PARAMETER_NAMES
 from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
@@ -18,6 +19,7 @@ from gwmock_pop.validation import validate_sample
 from gwmock_pop.version import __version__
 
 __all__ = [
+    "CBC_PARAMETER_NAMES",
     "BBHSimulator",
     "BNSPriorSimulator",
     "CBCPriorSimulator",

--- a/src/gwmock_pop/constants/__init__.py
+++ b/src/gwmock_pop/constants/__init__.py
@@ -1,7 +1,36 @@
-"""Modules for physical constants."""
+"""Physical constants and public parameter-name contracts."""
 
 from __future__ import annotations
+
+_CBC_PARAMETER_NAME_SEQUENCE = (
+    "detector_frame_mass_1",
+    "detector_frame_mass_2",
+    "spin_1x",
+    "spin_1y",
+    "spin_1z",
+    "spin_2x",
+    "spin_2y",
+    "spin_2z",
+    "eccentricity",
+    "distance",
+    "coa_phase",
+    "inclination",
+    "theta_jn",
+    "long_asc_node",
+    "mean_per_ano",
+    "coa_time",
+    "right_ascension",
+    "declination",
+    "polarization_angle",
+    "redshift",
+    "f_ref",
+)
+
+# Canonical gwmock-* CBC parameter names used at the public package boundary.
+CBC_PARAMETER_NAMES = frozenset(_CBC_PARAMETER_NAME_SEQUENCE)
 
 # Speed of light in m/s.
 # Reference: CODATA 2018
 SPEED_OF_LIGHT = 299792458.0
+
+__all__ = ["CBC_PARAMETER_NAMES", "SPEED_OF_LIGHT"]

--- a/src/gwmock_pop/simulators/bbh/base.py
+++ b/src/gwmock_pop/simulators/bbh/base.py
@@ -6,6 +6,7 @@ from importlib.resources import as_file
 from typing import Any
 
 from gwmock_pop.configs import get_packaged_preset, get_packaged_preset_resource
+from gwmock_pop.constants import _CBC_PARAMETER_NAME_SEQUENCE
 from gwmock_pop.mixins.random import RandomMixin
 from gwmock_pop.simulators.graph import GraphSimulator
 from gwmock_pop.simulators.simulator import Simulator
@@ -84,29 +85,7 @@ class BBHSimulator(RandomMixin, Simulator):
         # Allow subclasses to override with dynamic parameter names
         if hasattr(self, "_parameter_names"):
             return self._parameter_names
-        return [
-            "detector_frame_mass_1",
-            "detector_frame_mass_2",
-            "spin_1x",
-            "spin_1y",
-            "spin_1z",
-            "spin_2x",
-            "spin_2y",
-            "spin_2z",
-            "eccentricity",
-            "distance",
-            "coa_phase",
-            "inclination",
-            "theta_jn",
-            "long_asc_node",
-            "mean_per_ano",
-            "coa_time",
-            "right_ascension",
-            "declination",
-            "polarization_angle",
-            "redshift",
-            "f_ref",
-        ]
+        return list(_CBC_PARAMETER_NAME_SEQUENCE)
 
     @property
     def source_type(self) -> str:

--- a/tests/constants/test_constants.py
+++ b/tests/constants/test_constants.py
@@ -1,7 +1,33 @@
 """Unit tests for gwmock_pop.constants."""
 
+from gwmock_pop import CBC_PARAMETER_NAMES
 from gwmock_pop.constants import SPEED_OF_LIGHT
 
+EXPECTED_CBC_PARAMETER_NAMES = frozenset(
+    {
+        "detector_frame_mass_1",
+        "detector_frame_mass_2",
+        "spin_1x",
+        "spin_1y",
+        "spin_1z",
+        "spin_2x",
+        "spin_2y",
+        "spin_2z",
+        "eccentricity",
+        "distance",
+        "coa_phase",
+        "inclination",
+        "theta_jn",
+        "long_asc_node",
+        "mean_per_ano",
+        "coa_time",
+        "right_ascension",
+        "declination",
+        "polarization_angle",
+        "redshift",
+        "f_ref",
+    }
+)
 SPEED_OF_LIGHT_REFERENCE = 299792458.0
 
 
@@ -11,3 +37,12 @@ class TestConstants:
     def test_speed_of_light(self):
         """Compare the speed of light with the expected value."""
         assert SPEED_OF_LIGHT == SPEED_OF_LIGHT_REFERENCE
+
+    def test_cbc_parameter_names_is_public_frozenset(self) -> None:
+        """CBC parameter names are exported as a 21-name frozenset."""
+        assert isinstance(CBC_PARAMETER_NAMES, frozenset)
+        assert len(CBC_PARAMETER_NAMES) == 21
+
+    def test_cbc_parameter_names_match_notes_table(self) -> None:
+        """CBC parameter names match the canonical NOTES table."""
+        assert CBC_PARAMETER_NAMES == EXPECTED_CBC_PARAMETER_NAMES

--- a/tests/simulators/bbh/test_simulators_bbh_base.py
+++ b/tests/simulators/bbh/test_simulators_bbh_base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import jax.numpy as jnp
 
+from gwmock_pop import CBC_PARAMETER_NAMES
 from gwmock_pop.protocols import GWPopSimulator
 from gwmock_pop.simulators.bbh.base import BBHSimulator
 
@@ -79,6 +80,11 @@ class TestBBHSimulator:
         simulator = ConcreteBBHSimulator()
         num_bbh_parameters = 21
         assert len(simulator.parameter_names) == num_bbh_parameters
+
+    def test_parameter_names_are_subset_of_cbc_parameter_names(self) -> None:
+        """BBHSimulator parameters stay within the public CBC contract."""
+        simulator = ConcreteBBHSimulator()
+        assert set(simulator.parameter_names).issubset(CBC_PARAMETER_NAMES)
 
     def test_source_type_is_bbh(self) -> None:
         """Test that source_type returns 'bbh'."""

--- a/tests/simulators/test_bns_prior.py
+++ b/tests/simulators/test_bns_prior.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from gwmock_pop import BNSPriorSimulator
+from gwmock_pop import CBC_PARAMETER_NAMES, BNSPriorSimulator
 from gwmock_pop.protocols import GWPopSimulator
 from gwmock_pop.simulators import BNSPriorSimulator as SimulatorsBNSPriorSimulator
 
@@ -17,6 +17,12 @@ def test_simulate_returns_expected_shape_and_keys() -> None:
 
     assert list(result.keys()) == simulator.parameter_names
     assert all(array.shape == (1000,) for array in result.values())
+
+
+def test_parameter_names_are_subset_of_cbc_parameter_names() -> None:
+    """BNSPriorSimulator parameters stay within the public CBC contract."""
+    simulator = BNSPriorSimulator()
+    assert set(simulator.parameter_names).issubset(CBC_PARAMETER_NAMES)
 
 
 def test_simulate_is_reproducible_for_fixed_seed() -> None:

--- a/tests/simulators/test_cbc_prior.py
+++ b/tests/simulators/test_cbc_prior.py
@@ -13,7 +13,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from gwmock_pop import CBCPriorSimulator
+from gwmock_pop import CBC_PARAMETER_NAMES, CBCPriorSimulator
 from gwmock_pop.protocols import GWPopSimulator
 from gwmock_pop.simulators import cbc_prior as cbc_prior_module
 
@@ -42,6 +42,12 @@ def test_simulate_returns_expected_shape_and_keys() -> None:
 
     assert list(result.keys()) == simulator.parameter_names
     assert all(array.shape == (1000,) for array in result.values())
+
+
+def test_parameter_names_are_subset_of_cbc_parameter_names() -> None:
+    """CBCPriorSimulator parameters stay within the public CBC contract."""
+    simulator = CBCPriorSimulator()
+    assert set(simulator.parameter_names).issubset(CBC_PARAMETER_NAMES)
 
 
 def test_simulate_is_reproducible_for_fixed_seed() -> None:

--- a/tests/simulators/test_nsbh_prior.py
+++ b/tests/simulators/test_nsbh_prior.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from gwmock_pop import NSBHPriorSimulator
+from gwmock_pop import CBC_PARAMETER_NAMES, NSBHPriorSimulator
 from gwmock_pop.protocols import GWPopSimulator
 from gwmock_pop.simulators import NSBHPriorSimulator as SimulatorsNSBHPriorSimulator
 
@@ -22,6 +22,12 @@ def test_simulate_returns_expected_shape_and_keys() -> None:
 
     assert list(result.keys()) == simulator.parameter_names
     assert all(array.shape == (1000,) for array in result.values())
+
+
+def test_parameter_names_are_subset_of_cbc_parameter_names() -> None:
+    """NSBHPriorSimulator parameters stay within the public CBC contract."""
+    simulator = NSBHPriorSimulator()
+    assert set(simulator.parameter_names).issubset(CBC_PARAMETER_NAMES)
 
 
 def test_simulate_is_reproducible_for_fixed_seed() -> None:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -25,6 +25,7 @@ def get_all_submodules(package):
 def test_import_main_package():
     """Test that the main gwmock_pop package can be imported."""
     assert hasattr(gwmock_pop, "__version__")
+    assert hasattr(gwmock_pop, "CBC_PARAMETER_NAMES")
     assert gwmock_pop.__version__ is not None
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed a canonical set of CBC (Compact Binary Coalescence) parameter names as a public constant for reference and validation across all simulators.

* **Tests**
  * Added comprehensive test coverage to ensure all simulators comply with the canonical parameter specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->