### PR TITLE
feat: FilePopulationLoader now accepts remote http://, https://, s3://, and zenodo://... sources

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,13 +39,6 @@ repos:
       hooks:
           - id: taplo-format
 
-    - repo: https://github.com/PyCQA/bandit
-      rev: '1.9.4'
-      hooks:
-          - id: bandit
-            args: ['-c', 'pyproject.toml']
-            additional_dependencies: ['.[toml]']
-
     - repo: https://github.com/rbubley/mirrors-prettier
       rev: v3.8.3
       hooks:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ gravitational-wave sources.
   used in mixture workflows).
 - **Catalogues:** `FilePopulationLoader` and `read_population_catalogue` /
   `write_population_catalogue` for CSV and HDF5 (structured or group-of-datasets
-  layouts).
+  layouts), including remote URL loading with local caching and CBC
+  canonicalization in the loader.
 - **Quality checks:** `validate_sample` for arrays returned by simulators.
 
 Public re-exports live in `gwmock_pop.__all__`; full module reference is in the
@@ -112,6 +113,12 @@ assert population["detector_frame_mass_1"].shape == (100,)
 
 Use `GraphSimulator.from_config_file(...)` or `GraphSimulator.from_preset(...)`
 for full graph configs (see `examples/` and `gwmock_pop.simulators.graph`).
+
+`FilePopulationLoader` also accepts `http://`, `https://`, `s3://`, and
+`zenodo://<record>/<file>` sources. Remote catalogues are cached under
+`${GWMOCK_POP_CACHE_DIR}` or `${XDG_CACHE_HOME:-~/.cache}/gwmock-pop`, and CBC
+catalogues are validated and rewritten to canonical gwmock-pop parameter names
+before sampling.
 
 ## Verification
 

--- a/docs/api/loaders/index.md
+++ b/docs/api/loaders/index.md
@@ -1,6 +1,6 @@
 ---
 title: Loaders
-description: File-backed population catalogues (CSV, HDF5).
+description: File-backed population catalogues (CSV, HDF5, cached remote URLs).
 ---
 
 ::: gwmock_pop.loaders

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
 [dependency-groups]
 dev = [
   "astropy>=7.2.0",
-  "bandit[toml]>=1.9.4",
   "hypothesis>=6.152.4",
   "pre-commit>=4.6.0",
   "pytest-cov>=7.1.0",
@@ -64,12 +63,6 @@ source = "uv-dynamic-versioning"
 [tool.hatch.build.targets.wheel]
 packages = ["src/gwmock_pop"]
 include = ["src/gwmock_pop/configs/*.yaml"]
-
-[tool.bandit]
-exclude_dirs = ["build", "dist", "tests", "scripts"]
-number = 4
-recursive = true
-targets = "src"
 
 [tool.coverage.run]
 branch = true
@@ -112,6 +105,7 @@ lint.extend-select = [
   "T10", # Debugger statements
   "DOC", # Docstring
   "D",   # Doc style
+  "S",   # Security
 ]
 lint.ignore = [
   "E501", # Line length (handled by formatter)

--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from gwmock_pop.configs import list_presets
 from gwmock_pop.constants import CBC_PARAMETER_NAMES
-from gwmock_pop.exceptions import PopulationFetchError, PopulationValidationError
+from gwmock_pop.exceptions import PopulationError, PopulationFetchError, PopulationValidationError
 from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
@@ -31,6 +31,7 @@ __all__ = [
     "MixtureSimulator",
     "NSBHPriorSimulator",
     "PoissonEventSampler",
+    "PopulationError",
     "PopulationFetchError",
     "PopulationValidationError",
     "__version__",

--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from gwmock_pop.configs import list_presets
 from gwmock_pop.constants import CBC_PARAMETER_NAMES
+from gwmock_pop.exceptions import PopulationFetchError, PopulationValidationError
 from gwmock_pop.loaders import FilePopulationLoader
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
@@ -30,6 +31,8 @@ __all__ = [
     "MixtureSimulator",
     "NSBHPriorSimulator",
     "PoissonEventSampler",
+    "PopulationFetchError",
+    "PopulationValidationError",
     "__version__",
     "list_presets",
     "validate_sample",

--- a/src/gwmock_pop/exceptions.py
+++ b/src/gwmock_pop/exceptions.py
@@ -1,0 +1,18 @@
+"""Typed exceptions for external population loading."""
+
+from __future__ import annotations
+
+
+class PopulationError(Exception):
+    """Base exception for population-loading failures."""
+
+
+class PopulationFetchError(PopulationError):
+    """Raised when a remote population catalogue cannot be fetched."""
+
+
+class PopulationValidationError(PopulationError, ValueError):
+    """Raised when a population catalogue fails schema or data validation."""
+
+
+__all__ = ["PopulationError", "PopulationFetchError", "PopulationValidationError"]

--- a/src/gwmock_pop/loaders/_fetch.py
+++ b/src/gwmock_pop/loaders/_fetch.py
@@ -30,11 +30,20 @@ class FetchResult:
     """Resolved file location and fetch metadata."""
 
     path: Path
+    """Resolved file path."""
     metadata: dict[str, Any]
+    """Fetch metadata."""
 
 
 def is_population_url(path: str | os.PathLike[str]) -> bool:
-    """Return whether ``path`` is a supported remote URL."""
+    """Return whether ``path`` is a supported remote URL.
+
+    Args:
+        path: The path to check.
+
+    Returns:
+        Whether the path is a supported remote URL.
+    """
     return urlparse(os.fspath(path)).scheme.lower() in _SUPPORTED_URL_SCHEMES
 
 
@@ -47,7 +56,19 @@ def resolve_population_path(  # noqa: PLR0913
     credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None = None,
     timeout: int = 300,
 ) -> FetchResult:
-    """Resolve a local path or fetch a remote URL into the population cache."""
+    """Resolve a local path or fetch a remote URL into the population cache.
+
+    Args:
+        path: The path to resolve.
+        cache_dir: The directory to cache the population in.
+        refresh: Whether to refresh the cache.
+        token: The token to use for authentication.
+        credentials: The credentials to use for authentication.
+        timeout: The timeout for the request.
+
+    Returns:
+        The resolved path and fetch metadata.
+    """
     original_path = os.fspath(path)
     if not is_population_url(original_path):
         resolved_path = Path(original_path).expanduser()
@@ -96,6 +117,7 @@ def resolve_population_path(  # noqa: PLR0913
             parsed=parsed,
             destination=cache_path,
             credentials=credentials,
+            timeout=timeout,
         )
     else:
         download_metadata = _download_http_url(
@@ -119,7 +141,14 @@ def resolve_population_path(  # noqa: PLR0913
 
 
 def _resolve_cache_dir(cache_dir: str | os.PathLike[str] | None) -> Path:
-    """Resolve the configured population cache directory."""
+    """Resolve the configured population cache directory.
+
+    Args:
+        cache_dir: The directory to cache the population in.
+
+    Returns:
+        The resolved cache directory.
+    """
     if cache_dir is not None:
         return Path(cache_dir).expanduser()
 
@@ -135,7 +164,14 @@ def _resolve_cache_dir(cache_dir: str | os.PathLike[str] | None) -> Path:
 
 
 def _resolve_remote_url(parsed) -> str:
-    """Translate custom URL schemes into fetchable URLs."""
+    """Translate custom URL schemes into fetchable URLs.
+
+    Args:
+        parsed: The parsed URL.
+
+    Returns:
+        The resolved URL.
+    """
     if parsed.scheme.lower() != "zenodo":
         return parsed.geturl()
 
@@ -149,7 +185,14 @@ def _resolve_remote_url(parsed) -> str:
 
 
 def _infer_cache_suffix(url: str) -> str:
-    """Infer a stable file suffix for a cached remote object."""
+    """Infer a stable file suffix for a cached remote object.
+
+    Args:
+        url: The URL to infer the cache suffix for.
+
+    Returns:
+        The inferred cache suffix.
+    """
     suffix = Path(urlparse(url).path).suffix.lower()
     return suffix or ".download"
 
@@ -160,7 +203,16 @@ def _build_request_headers(
     token: str | None,
     credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None,
 ) -> dict[str, str]:
-    """Construct request headers from explicit credentials or environment."""
+    """Construct request headers from explicit credentials or environment.
+
+    Args:
+        scheme: The scheme of the URL.
+        token: The token to use for authentication.
+        credentials: The credentials to use for authentication.
+
+    Returns:
+        The constructed request headers.
+    """
     headers: dict[str, str] = {}
     if credentials is not None:
         raw_headers: Mapping[str, str]
@@ -180,7 +232,14 @@ def _build_request_headers(
 
 
 def _resolve_token_from_environment(scheme: str) -> str | None:
-    """Resolve a scheme-specific token from the environment."""
+    """Resolve a scheme-specific token from the environment.
+
+    Args:
+        scheme: The scheme of the URL.
+
+    Returns:
+        The resolved token.
+    """
     if scheme == "zenodo" and os.environ.get(_ZENODO_TOKEN_ENV_VAR):
         return os.environ[_ZENODO_TOKEN_ENV_VAR]
     return os.environ.get(_TOKEN_ENV_VAR)
@@ -193,7 +252,17 @@ def _download_http_url(
     headers: Mapping[str, str],
     timeout: int,
 ) -> dict[str, Any]:
-    """Download a remote HTTP(S)-accessible file to the cache."""
+    """Download a remote HTTP(S)-accessible file to the cache.
+
+    Args:
+        url: The URL to download.
+        destination: The destination path to save the file to.
+        headers: The headers to use for the request.
+        timeout: The timeout for the request.
+
+    Returns:
+        The download metadata.
+    """
     parsed = urlparse(url)
 
     if parsed.scheme.lower() not in {"http", "https"}:
@@ -227,15 +296,28 @@ def _download_s3_url(
     parsed,
     destination: Path,
     credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None,
+    timeout: int,
 ) -> dict[str, Any]:
-    """Download an object from S3 using boto3 when available."""
+    """Download an object from S3 using boto3 when available.
+
+    Args:
+        parsed: The parsed URL.
+        destination: The destination path to save the file to.
+        credentials: The credentials to use for authentication.
+        timeout: The timeout for the request.
+
+    Returns:
+        The download metadata.
+    """
     try:
         boto3 = importlib.import_module("boto3")
         botocore_exceptions = importlib.import_module("botocore.exceptions")
+        botocore_config_mod = importlib.import_module("botocore.config")
     except ImportError as exc:
         raise PopulationFetchError("s3:// population URLs require boto3 and botocore to be installed.") from exc
     boto_core_error = botocore_exceptions.BotoCoreError
     client_error = botocore_exceptions.ClientError
+    boto_config = botocore_config_mod.Config(connect_timeout=timeout, read_timeout=timeout)
 
     bucket = parsed.netloc.strip()
     key = parsed.path.lstrip("/")
@@ -251,7 +333,7 @@ def _download_s3_url(
 
     temporary_path = _temporary_download_path(destination)
     try:
-        boto3.client("s3", **client_kwargs).download_file(bucket, key, str(temporary_path))
+        boto3.client("s3", config=boto_config, **client_kwargs).download_file(bucket, key, str(temporary_path))
     except (boto_core_error, client_error, OSError) as exc:
         temporary_path.unlink(missing_ok=True)
         raise PopulationFetchError(f"Failed to fetch population URL {parsed.geturl()!r}: {exc}.") from exc
@@ -264,7 +346,15 @@ def _download_s3_url(
 
 
 def _load_cached_metadata(cache_metadata_path: Path, *, fallback: dict[str, Any]) -> dict[str, Any]:
-    """Load cached fetch metadata, preserving the required runtime fields."""
+    """Load cached fetch metadata, preserving the required runtime fields.
+
+    Args:
+        cache_metadata_path: The path to the cached metadata file.
+        fallback: The fallback metadata to use if the file does not exist.
+
+    Returns:
+        The loaded metadata.
+    """
     if not cache_metadata_path.exists():
         return fallback
 
@@ -287,7 +377,14 @@ def _load_cached_metadata(cache_metadata_path: Path, *, fallback: dict[str, Any]
 
 
 def _temporary_download_path(destination: Path) -> Path:
-    """Create a temporary file path next to the target cache entry."""
+    """Create a temporary file path next to the target cache entry.
+
+    Args:
+        destination: The destination path to save the file to.
+
+    Returns:
+        The temporary file path.
+    """
     with tempfile.NamedTemporaryFile(
         dir=destination.parent,
         prefix=f"{destination.name}.",
@@ -298,7 +395,14 @@ def _temporary_download_path(destination: Path) -> Path:
 
 
 def _sha256_file(path: Path) -> str:
-    """Compute the SHA256 digest of a downloaded cache entry."""
+    """Compute the SHA256 digest of a downloaded cache entry.
+
+    Args:
+        path: The path to the file to compute the SHA256 digest of.
+
+    Returns:
+        The SHA256 digest.
+    """
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):

--- a/src/gwmock_pop/loaders/_fetch.py
+++ b/src/gwmock_pop/loaders/_fetch.py
@@ -1,0 +1,309 @@
+"""Remote population-file fetching and local cache resolution."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+from gwmock_pop.exceptions import PopulationFetchError
+
+_CACHE_ENV_VAR = "GWMOCK_POP_CACHE_DIR"
+_TOKEN_ENV_VAR = "GWMOCK_POP_TOKEN"  # noqa: S105
+_ZENODO_TOKEN_ENV_VAR = "ZENODO_TOKEN"  # noqa: S105
+_SUPPORTED_URL_SCHEMES = frozenset({"http", "https", "s3", "zenodo"})
+_HTTP_RESPONSE_HEADER_KEYS = ("Content-Length", "Content-Type", "ETag", "Last-Modified")
+
+
+@dataclass(frozen=True, slots=True)
+class FetchResult:
+    """Resolved file location and fetch metadata."""
+
+    path: Path
+    metadata: dict[str, Any]
+
+
+def is_population_url(path: str | os.PathLike[str]) -> bool:
+    """Return whether ``path`` is a supported remote URL."""
+    return urlparse(os.fspath(path)).scheme.lower() in _SUPPORTED_URL_SCHEMES
+
+
+def resolve_population_path(  # noqa: PLR0913
+    path: str | os.PathLike[str],
+    *,
+    cache_dir: str | os.PathLike[str] | None = None,
+    refresh: bool = False,
+    token: str | None = None,
+    credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None = None,
+    timeout: int = 300,
+) -> FetchResult:
+    """Resolve a local path or fetch a remote URL into the population cache."""
+    original_path = os.fspath(path)
+    if not is_population_url(original_path):
+        resolved_path = Path(original_path).expanduser()
+        return FetchResult(
+            path=resolved_path,
+            metadata={
+                "cache_hit": False,
+                "original_path": original_path,
+                "remote": False,
+                "resolved_path": str(resolved_path),
+            },
+        )
+
+    parsed = urlparse(original_path)
+    cache_root = _resolve_cache_dir(cache_dir)
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    resolved_url = _resolve_remote_url(parsed)
+    cache_key = hashlib.sha256(original_path.encode("utf-8")).hexdigest()
+    cache_path = cache_root / f"{cache_key}{_infer_cache_suffix(resolved_url)}"
+    cache_metadata_path = cache_root / f"{cache_key}.json"
+
+    if cache_path.exists() and not refresh:
+        return FetchResult(
+            path=cache_path,
+            metadata=_load_cached_metadata(
+                cache_metadata_path,
+                fallback={
+                    "cache_hit": True,
+                    "cache_path": str(cache_path),
+                    "original_url": original_path,
+                    "remote": True,
+                    "resolved_url": resolved_url,
+                    "scheme": parsed.scheme.lower(),
+                },
+            ),
+        )
+
+    headers = _build_request_headers(
+        scheme=parsed.scheme.lower(),
+        token=token,
+        credentials=credentials,
+    )
+    if parsed.scheme.lower() == "s3":
+        download_metadata = _download_s3_url(
+            parsed=parsed,
+            destination=cache_path,
+            credentials=credentials,
+        )
+    else:
+        download_metadata = _download_http_url(
+            resolved_url,
+            destination=cache_path,
+            headers=headers,
+            timeout=timeout,
+        )
+
+    fetch_metadata = {
+        **download_metadata,
+        "cache_hit": False,
+        "cache_path": str(cache_path),
+        "original_url": original_path,
+        "remote": True,
+        "resolved_url": resolved_url,
+        "scheme": parsed.scheme.lower(),
+    }
+    cache_metadata_path.write_text(json.dumps(fetch_metadata, sort_keys=True, indent=2), encoding="utf-8")
+    return FetchResult(path=cache_path, metadata=fetch_metadata)
+
+
+def _resolve_cache_dir(cache_dir: str | os.PathLike[str] | None) -> Path:
+    """Resolve the configured population cache directory."""
+    if cache_dir is not None:
+        return Path(cache_dir).expanduser()
+
+    env_cache_dir = os.environ.get(_CACHE_ENV_VAR)
+    if env_cache_dir:
+        return Path(env_cache_dir).expanduser()
+
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+    if xdg_cache_home:
+        return Path(xdg_cache_home).expanduser() / "gwmock-pop"
+
+    return Path.home() / ".cache" / "gwmock-pop"
+
+
+def _resolve_remote_url(parsed) -> str:
+    """Translate custom URL schemes into fetchable URLs."""
+    if parsed.scheme.lower() != "zenodo":
+        return parsed.geturl()
+
+    record_id = parsed.netloc.strip()
+    file_name = parsed.path.lstrip("/")
+    if not record_id or not file_name:
+        raise PopulationFetchError(
+            "Zenodo URLs must use the form 'zenodo://<record>/<file>' so the record and file are unambiguous."
+        )
+    return f"https://zenodo.org/records/{quote(record_id)}/files/{quote(file_name)}?download=1"
+
+
+def _infer_cache_suffix(url: str) -> str:
+    """Infer a stable file suffix for a cached remote object."""
+    suffix = Path(urlparse(url).path).suffix.lower()
+    return suffix or ".download"
+
+
+def _build_request_headers(
+    *,
+    scheme: str,
+    token: str | None,
+    credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None,
+) -> dict[str, str]:
+    """Construct request headers from explicit credentials or environment."""
+    headers: dict[str, str] = {}
+    if credentials is not None:
+        raw_headers: Mapping[str, str]
+        if "headers" in credentials:
+            nested_headers = credentials["headers"]
+            if not isinstance(nested_headers, Mapping):
+                raise PopulationFetchError("'credentials[\"headers\"]' must be a mapping of header names to values.")
+            raw_headers = nested_headers
+        else:
+            raw_headers = credentials
+        headers.update({str(name): str(value) for name, value in raw_headers.items()})
+
+    resolved_token = token or _resolve_token_from_environment(scheme)
+    if resolved_token and "Authorization" not in headers:
+        headers["Authorization"] = f"Bearer {resolved_token}"
+    return headers
+
+
+def _resolve_token_from_environment(scheme: str) -> str | None:
+    """Resolve a scheme-specific token from the environment."""
+    if scheme == "zenodo" and os.environ.get(_ZENODO_TOKEN_ENV_VAR):
+        return os.environ[_ZENODO_TOKEN_ENV_VAR]
+    return os.environ.get(_TOKEN_ENV_VAR)
+
+
+def _download_http_url(
+    url: str,
+    *,
+    destination: Path,
+    headers: Mapping[str, str],
+    timeout: int,
+) -> dict[str, Any]:
+    """Download a remote HTTP(S)-accessible file to the cache."""
+    parsed = urlparse(url)
+
+    if parsed.scheme.lower() not in {"http", "https"}:
+        raise ValueError("URL must use http or https")
+
+    request = Request(url, headers=dict(headers))  # noqa: S310
+    temporary_path = _temporary_download_path(destination)
+
+    try:
+        with urlopen(request, timeout=timeout) as response, temporary_path.open("wb") as handle:  # noqa: S310
+            shutil.copyfileobj(response, handle)
+            response_headers = {
+                key: value for key in _HTTP_RESPONSE_HEADER_KEYS if (value := response.headers.get(key)) is not None
+            }
+    except HTTPError as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise PopulationFetchError(f"Failed to fetch population URL {url!r}: HTTP {exc.code} {exc.reason}.") from exc
+    except (TimeoutError, URLError, OSError) as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise PopulationFetchError(f"Failed to fetch population URL {url!r}: {exc}.") from exc
+
+    temporary_path.replace(destination)
+    return {
+        "content_sha256": _sha256_file(destination),
+        "headers": response_headers,
+    }
+
+
+def _download_s3_url(
+    *,
+    parsed,
+    destination: Path,
+    credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None,
+) -> dict[str, Any]:
+    """Download an object from S3 using boto3 when available."""
+    try:
+        boto3 = importlib.import_module("boto3")
+        botocore_exceptions = importlib.import_module("botocore.exceptions")
+    except ImportError as exc:
+        raise PopulationFetchError("s3:// population URLs require boto3 and botocore to be installed.") from exc
+    boto_core_error = botocore_exceptions.BotoCoreError
+    client_error = botocore_exceptions.ClientError
+
+    bucket = parsed.netloc.strip()
+    key = parsed.path.lstrip("/")
+    if not bucket or not key:
+        raise PopulationFetchError("s3 URLs must use the form 's3://<bucket>/<key>' so the object is unambiguous.")
+
+    client_kwargs: dict[str, str] = {}
+    if credentials is not None:
+        for field in ("aws_access_key_id", "aws_secret_access_key", "aws_session_token", "endpoint_url", "region_name"):
+            value = credentials.get(field)
+            if value is not None and not isinstance(value, Mapping):
+                client_kwargs[field] = str(value)
+
+    temporary_path = _temporary_download_path(destination)
+    try:
+        boto3.client("s3", **client_kwargs).download_file(bucket, key, str(temporary_path))
+    except (boto_core_error, client_error, OSError) as exc:
+        temporary_path.unlink(missing_ok=True)
+        raise PopulationFetchError(f"Failed to fetch population URL {parsed.geturl()!r}: {exc}.") from exc
+
+    temporary_path.replace(destination)
+    return {
+        "content_sha256": _sha256_file(destination),
+        "headers": {},
+    }
+
+
+def _load_cached_metadata(cache_metadata_path: Path, *, fallback: dict[str, Any]) -> dict[str, Any]:
+    """Load cached fetch metadata, preserving the required runtime fields."""
+    if not cache_metadata_path.exists():
+        return fallback
+
+    try:
+        cached_metadata = json.loads(cache_metadata_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise PopulationFetchError(
+            f"Cache metadata file {cache_metadata_path} is not valid JSON. Remove it or refresh the cache."
+        ) from exc
+
+    return {
+        **cached_metadata,
+        "cache_hit": True,
+        "cache_path": fallback["cache_path"],
+        "original_url": fallback["original_url"],
+        "remote": True,
+        "resolved_url": fallback["resolved_url"],
+        "scheme": fallback["scheme"],
+    }
+
+
+def _temporary_download_path(destination: Path) -> Path:
+    """Create a temporary file path next to the target cache entry."""
+    with tempfile.NamedTemporaryFile(
+        dir=destination.parent,
+        prefix=f"{destination.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        return Path(handle.name)
+
+
+def _sha256_file(path: Path) -> str:
+    """Compute the SHA256 digest of a downloaded cache entry."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+__all__ = ["FetchResult", "is_population_url", "resolve_population_path"]

--- a/src/gwmock_pop/loaders/_validate.py
+++ b/src/gwmock_pop/loaders/_validate.py
@@ -155,7 +155,7 @@ def _validate_array_shapes_and_lengths(catalogue: Mapping[str, np.ndarray]) -> N
 def _validate_numeric_values(catalogue: Mapping[str, np.ndarray]) -> None:
     """Validate that every catalogue column is numeric and finite."""
     for name, values in catalogue.items():
-        if not np.issubdtype(values.dtype, np.number):
+        if not (np.issubdtype(values.dtype, np.floating) or np.issubdtype(values.dtype, np.integer)):
             raise PopulationValidationError(f"Column {name!r} must contain numeric values, got dtype {values.dtype}.")
         if not np.all(np.isfinite(values)):
             invalid_index = int(np.flatnonzero(~np.isfinite(values))[0])

--- a/src/gwmock_pop/loaders/_validate.py
+++ b/src/gwmock_pop/loaders/_validate.py
@@ -1,0 +1,182 @@
+"""Population-catalogue validation and CBC canonicalization."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import numpy as np
+
+from gwmock_pop.constants import CBC_PARAMETER_NAMES
+from gwmock_pop.exceptions import PopulationValidationError
+
+_CBC_SOURCE_TYPES = frozenset({"bbh", "bns", "nsbh"})
+_CBC_REQUIRED_COLUMNS = frozenset({"detector_frame_mass_1", "detector_frame_mass_2"})
+_CBC_INTERNAL_COLUMNS = frozenset({"source_frame_mass_1", "source_frame_mass_2"})
+_CBC_CANONICAL_NAME_MAP = {
+    "m1": "detector_frame_mass_1",
+    "mass1": "detector_frame_mass_1",
+    "mass_1": "detector_frame_mass_1",
+    "detector_frame_mass_1": "detector_frame_mass_1",
+    "m2": "detector_frame_mass_2",
+    "mass2": "detector_frame_mass_2",
+    "mass_2": "detector_frame_mass_2",
+    "detector_frame_mass_2": "detector_frame_mass_2",
+    "m1_source": "source_frame_mass_1",
+    "mass1_source": "source_frame_mass_1",
+    "mass_1_source": "source_frame_mass_1",
+    "srcmass1": "source_frame_mass_1",
+    "source_frame_mass_1": "source_frame_mass_1",
+    "m2_source": "source_frame_mass_2",
+    "mass2_source": "source_frame_mass_2",
+    "mass_2_source": "source_frame_mass_2",
+    "srcmass2": "source_frame_mass_2",
+    "source_frame_mass_2": "source_frame_mass_2",
+    "chi1x": "spin_1x",
+    "chi1y": "spin_1y",
+    "chi1z": "spin_1z",
+    "chi2x": "spin_2x",
+    "chi2y": "spin_2y",
+    "chi2z": "spin_2z",
+    "spin1x": "spin_1x",
+    "spin1y": "spin_1y",
+    "spin1z": "spin_1z",
+    "spin2x": "spin_2x",
+    "spin2y": "spin_2y",
+    "spin2z": "spin_2z",
+    "dL": "distance",
+    "luminosity_distance": "distance",
+    "Phicoal": "coa_phase",
+    "iota": "inclination",
+    "tGPS": "coa_time",
+    "tc": "coa_time",
+    "ra": "right_ascension",
+    "dec": "declination",
+    "polarization": "polarization_angle",
+    "psi": "polarization_angle",
+    "z": "redshift",
+}
+
+
+def validate_population_catalogue(source_type: str, catalogue: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
+    """Validate a loaded population catalogue for the configured source type."""
+    normalized_catalogue = {name: np.atleast_1d(np.asarray(values)) for name, values in catalogue.items()}
+    _validate_array_shapes_and_lengths(normalized_catalogue)
+
+    if source_type.lower() not in _CBC_SOURCE_TYPES:
+        _validate_numeric_values(normalized_catalogue)
+        return normalized_catalogue
+
+    canonical_catalogue = _canonicalize_cbc_catalogue(normalized_catalogue, source_type=source_type)
+    canonical_catalogue = _derive_detector_frame_masses(canonical_catalogue)
+    _validate_array_shapes_and_lengths(canonical_catalogue)
+    _validate_numeric_values(canonical_catalogue)
+
+    public_catalogue = {name: values for name, values in canonical_catalogue.items() if name in CBC_PARAMETER_NAMES}
+    missing_columns = sorted(_CBC_REQUIRED_COLUMNS - set(public_catalogue))
+    if missing_columns:
+        missing_repr = ", ".join(missing_columns)
+        raise PopulationValidationError(
+            f"CBC population for source_type {source_type!r} is missing required canonical columns: {missing_repr}."
+        )
+    return public_catalogue
+
+
+def _canonicalize_cbc_catalogue(catalogue: Mapping[str, np.ndarray], *, source_type: str) -> dict[str, np.ndarray]:
+    """Canonicalize CBC aliases to the gwmock-pop public parameter names."""
+    canonical_catalogue: dict[str, np.ndarray] = {}
+    provenance_by_target: dict[str, str] = {}
+    valid_targets = CBC_PARAMETER_NAMES | _CBC_INTERNAL_COLUMNS
+
+    for original_name, values in catalogue.items():
+        target_name = _CBC_CANONICAL_NAME_MAP.get(original_name, original_name)
+        if target_name not in valid_targets:
+            raise PopulationValidationError(
+                f"Column {original_name!r} is not recognized for CBC source_type {source_type!r}."
+            )
+        if target_name in canonical_catalogue:
+            previous_name = provenance_by_target[target_name]
+            raise PopulationValidationError(
+                f"Columns {previous_name!r} and {original_name!r} both map to canonical name {target_name!r}."
+            )
+        provenance_by_target[target_name] = original_name
+        canonical_catalogue[target_name] = values
+
+    return canonical_catalogue
+
+
+def _derive_detector_frame_masses(catalogue: Mapping[str, np.ndarray]) -> dict[str, np.ndarray]:
+    """Derive detector-frame masses from source-frame masses and redshift when needed."""
+    derived_catalogue = dict(catalogue)
+    redshift = derived_catalogue.get("redshift")
+
+    if "detector_frame_mass_1" not in derived_catalogue:
+        source_mass_1 = derived_catalogue.get("source_frame_mass_1")
+        if source_mass_1 is None or redshift is None:
+            raise PopulationValidationError(
+                "Missing detector_frame_mass_1. Provide 'detector_frame_mass_1' directly or provide "
+                "'source_frame_mass_1' together with 'redshift'."
+            )
+        _require_matching_lengths("source_frame_mass_1", source_mass_1, "redshift", redshift)
+        derived_catalogue["detector_frame_mass_1"] = source_mass_1 * (1.0 + redshift)
+
+    if "detector_frame_mass_2" not in derived_catalogue:
+        source_mass_2 = derived_catalogue.get("source_frame_mass_2")
+        if source_mass_2 is None or redshift is None:
+            raise PopulationValidationError(
+                "Missing detector_frame_mass_2. Provide 'detector_frame_mass_2' directly or provide "
+                "'source_frame_mass_2' together with 'redshift'."
+            )
+        _require_matching_lengths("source_frame_mass_2", source_mass_2, "redshift", redshift)
+        derived_catalogue["detector_frame_mass_2"] = source_mass_2 * (1.0 + redshift)
+
+    return derived_catalogue
+
+
+def _validate_array_shapes_and_lengths(catalogue: Mapping[str, np.ndarray]) -> None:
+    """Validate that every catalogue column is a non-empty 1-D array of matching length."""
+    if not catalogue:
+        raise PopulationValidationError("Loaded catalogue is empty.")
+
+    expected_length: int | None = None
+    for name, values in catalogue.items():
+        if values.ndim != 1:
+            raise PopulationValidationError(f"Column {name!r} must be a 1-D array, got shape {values.shape}.")
+        if expected_length is None:
+            expected_length = len(values)
+            if expected_length == 0:
+                raise PopulationValidationError(f"Column {name!r} is empty.")
+            continue
+        if len(values) != expected_length:
+            raise PopulationValidationError(
+                f"Column {name!r} has length {len(values)} but expected {expected_length} to match the catalogue."
+            )
+
+
+def _validate_numeric_values(catalogue: Mapping[str, np.ndarray]) -> None:
+    """Validate that every catalogue column is numeric and finite."""
+    for name, values in catalogue.items():
+        if not np.issubdtype(values.dtype, np.number):
+            raise PopulationValidationError(f"Column {name!r} must contain numeric values, got dtype {values.dtype}.")
+        if not np.all(np.isfinite(values)):
+            invalid_index = int(np.flatnonzero(~np.isfinite(values))[0])
+            invalid_value = values[invalid_index]
+            raise PopulationValidationError(
+                f"Column {name!r} contains a non-finite value at index {invalid_index}: {invalid_value!r}."
+            )
+
+
+def _require_matching_lengths(
+    left_name: str,
+    left_values: np.ndarray,
+    right_name: str,
+    right_values: np.ndarray,
+) -> None:
+    """Validate that two arrays can participate in element-wise derivations."""
+    if len(left_values) != len(right_values):
+        raise PopulationValidationError(
+            f"Cannot derive values because {left_name!r} has length {len(left_values)} but "
+            f"{right_name!r} has length {len(right_values)}."
+        )
+
+
+__all__ = ["validate_population_catalogue"]

--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -1,4 +1,4 @@
-"""Concrete external population loader for file-backed catalogues."""
+"""Concrete external population loader for local or cached file-backed catalogues."""
 
 from __future__ import annotations
 
@@ -12,6 +12,10 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+
+from gwmock_pop.exceptions import PopulationValidationError
+from gwmock_pop.loaders._fetch import resolve_population_path
+from gwmock_pop.loaders._validate import validate_population_catalogue
 
 _HDF5_DATASET_NAME = "data"
 _SUPPORTED_CATALOGUE_SUFFIXES = {".csv": "csv", ".hdf5": "hdf5", ".h5": "hdf5"}
@@ -122,25 +126,37 @@ class FilePopulationLoader:
     inheritance hierarchy.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         source_type: str,
         path: str | os.PathLike,
         *,
         column_map: dict[str, str] | None = None,
         hdf5_dataset: str = _HDF5_DATASET_NAME,
+        cache_dir: str | os.PathLike[str] | None = None,
+        refresh: bool = False,
+        token: str | None = None,
+        credentials: Mapping[str, str] | Mapping[str, Mapping[str, str]] | None = None,
+        download_timeout: int = 300,
     ) -> None:
-        """Load and validate a population catalogue from disk.
+        """Load and validate a population catalogue from disk or a remote URL.
 
         Args:
             source_type: Non-empty routing key used by downstream simulators,
                 such as ``"bbh"`` or ``"bns"``.
-            path: Path to the input catalogue file. Supported formats are
-                ``.hdf5``, ``.h5``, and ``.csv``.
+            path: Path or supported URL to the input catalogue file. Supported
+                local and remote formats are ``.hdf5``, ``.h5``, and ``.csv``.
             column_map: Optional mapping from file column names to canonical
                 gwmock-pop parameter names. Keys must exist in the loaded
                 catalogue.
             hdf5_dataset: Dataset name to read from HDF5 files.
+            cache_dir: Optional cache directory for remotely fetched catalogues.
+            refresh: Whether to force a re-download for remote URLs even when a
+                cached copy already exists.
+            token: Optional bearer token used for authenticated remote fetches.
+            credentials: Optional mapping of request headers or scheme-specific
+                credential fields for remote fetches.
+            download_timeout: Timeout in seconds for HTTP(S) downloads.
 
         Raises:
             ValueError: If ``source_type`` is empty, the file format is
@@ -151,15 +167,35 @@ class FilePopulationLoader:
             raise ValueError("source_type must be a non-empty string.")
 
         self._source_type = source_type
-        self._path = Path(path)
 
-        raw_catalogue = read_population_catalogue(self._path, column_map=column_map or {}, hdf5_dataset=hdf5_dataset)
-        self._catalogue = {name: jnp.asarray(values) for name, values in raw_catalogue.items()}
+        fetch_result = resolve_population_path(
+            path,
+            cache_dir=cache_dir,
+            refresh=refresh,
+            token=token,
+            credentials=credentials,
+            timeout=download_timeout,
+        )
+        self._path = fetch_result.path
 
+        try:
+            raw_catalogue = read_population_catalogue(self._path, hdf5_dataset=hdf5_dataset)
+            mapped_catalogue = apply_population_column_map(raw_catalogue, column_map)
+            validated_catalogue = validate_population_catalogue(source_type, mapped_catalogue)
+        except ValueError as exc:
+            raise PopulationValidationError(str(exc)) from exc
+
+        self._catalogue = {name: jnp.asarray(values) for name, values in validated_catalogue.items()}
         if not self._catalogue:
-            raise ValueError("Loaded catalogue is empty.")
+            raise PopulationValidationError("Loaded catalogue is empty.")
 
         self._parameter_names = sorted(self._catalogue)
+        self._metadata = {
+            "fetch": fetch_result.metadata,
+            "original_path": os.fspath(path),
+            "resolved_path": str(self._path),
+            "source_type": source_type,
+        }
 
     @property
     def parameter_names(self) -> list[str]:
@@ -178,6 +214,11 @@ class FilePopulationLoader:
             Source type passed at construction time.
         """
         return self._source_type
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """Return loader metadata, including remote cache details when relevant."""
+        return self._metadata
 
     def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
         """Sample catalogue rows without replacement.

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -8,10 +8,17 @@ import h5py
 import numpy as np
 import pytest
 
-from gwmock_pop import FilePopulationLoader
+from gwmock_pop import FilePopulationLoader, PopulationValidationError
 from gwmock_pop.protocols import GWPopSimulator
 
 pytestmark = pytest.mark.integration
+_EXPECTED_CBC_COLUMNS = {
+    "detector_frame_mass_1",
+    "detector_frame_mass_2",
+    "distance",
+    "redshift",
+    "spin_1z",
+}
 
 
 def _catalogue_columns(n_rows: int = 200) -> dict[str, np.ndarray]:
@@ -61,7 +68,7 @@ def test_hdf5_round_trip(tmp_path: Path) -> None:
 
     assert isinstance(loader, GWPopSimulator)
     assert list(result.keys()) == loader.parameter_names
-    assert set(result) == set(columns)
+    assert set(result) == _EXPECTED_CBC_COLUMNS
     assert all(array.shape == (50,) for array in result.values())
 
 
@@ -76,7 +83,7 @@ def test_csv_round_trip(tmp_path: Path) -> None:
 
     assert isinstance(loader, GWPopSimulator)
     assert list(result.keys()) == loader.parameter_names
-    assert set(result) == set(columns)
+    assert set(result) == _EXPECTED_CBC_COLUMNS
     assert all(array.shape == (50,) for array in result.values())
 
 
@@ -91,7 +98,7 @@ def test_hdf5_group_round_trip(tmp_path: Path) -> None:
 
     assert isinstance(loader, GWPopSimulator)
     assert list(result.keys()) == loader.parameter_names
-    assert set(result) == set(columns)
+    assert set(result) == _EXPECTED_CBC_COLUMNS
     assert all(array.shape == (40,) for array in result.values())
 
 
@@ -110,7 +117,12 @@ def test_column_map_renames_keys(tmp_path: Path) -> None:
     loader = FilePopulationLoader(
         "bbh",
         path,
-        column_map={"m1": "mass_1", "m2": "mass_2", "z": "redshift", "spin1z": "spin_1z"},
+        column_map={
+            "m1": "detector_frame_mass_1",
+            "m2": "detector_frame_mass_2",
+            "z": "redshift",
+            "spin1z": "spin_1z",
+        },
     )
     result = loader.simulate(25, seed=9)
 
@@ -118,8 +130,8 @@ def test_column_map_renames_keys(tmp_path: Path) -> None:
     assert "m2" not in loader.parameter_names
     assert "z" not in loader.parameter_names
     assert "spin1z" not in loader.parameter_names
-    assert "mass_1" in loader.parameter_names
-    assert "mass_2" in loader.parameter_names
+    assert "detector_frame_mass_1" in loader.parameter_names
+    assert "detector_frame_mass_2" in loader.parameter_names
     assert "redshift" in loader.parameter_names
     assert "spin_1z" in loader.parameter_names
     assert list(result.keys()) == loader.parameter_names
@@ -179,5 +191,5 @@ def test_unsupported_format_raises(tmp_path: Path) -> None:
     path = tmp_path / "catalogue.fits"
     path.write_text("not-a-supported-catalogue\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match=r"Supported formats are: \.hdf5, \.h5, \.csv"):
+    with pytest.raises(PopulationValidationError, match=r"Supported suffixes: \.csv, \.h5, \.hdf5"):
         FilePopulationLoader("bbh", path)

--- a/tests/loaders/test_file_loader_urls.py
+++ b/tests/loaders/test_file_loader_urls.py
@@ -1,0 +1,109 @@
+"""Unit tests for remote ``FilePopulationLoader`` inputs."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+from gwmock_pop import FilePopulationLoader, PopulationFetchError
+from gwmock_pop.loaders import _fetch
+
+
+class _MockResponse(BytesIO):
+    """Minimal file-like HTTP response for urlopen patches."""
+
+    def __init__(self, payload: bytes, *, headers: dict[str, str] | None = None) -> None:
+        super().__init__(payload)
+        self.headers = headers or {}
+
+    def __enter__(self) -> _MockResponse:
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb) -> bool:
+        self.close()
+        return False
+
+
+def _catalogue_bytes(rows: tuple[tuple[float, float, float], ...] = ((30.0, 20.0, 0.1), (35.0, 25.0, 0.2))) -> bytes:
+    """Encode a small CBC catalogue as CSV bytes."""
+    csv_rows = ["m1,m2,z"]
+    csv_rows.extend(f"{mass_1},{mass_2},{redshift}" for mass_1, mass_2, redshift in rows)
+    return ("\n".join(csv_rows) + "\n").encode("utf-8")
+
+
+def test_remote_loader_uses_cache_without_refetch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A cached HTTP catalogue is reused on subsequent loader construction."""
+    calls: list[str] = []
+
+    def fake_urlopen(request, *, timeout: int) -> _MockResponse:
+        calls.append(request.full_url)
+        return _MockResponse(_catalogue_bytes(), headers={"ETag": "abc123"})
+
+    monkeypatch.setattr(_fetch, "urlopen", fake_urlopen)
+
+    url = "https://example.com/population.csv"
+    first_loader = FilePopulationLoader("bbh", url, cache_dir=tmp_path)
+    second_loader = FilePopulationLoader("bbh", url, cache_dir=tmp_path)
+
+    assert len(calls) == 1
+    assert first_loader.metadata["fetch"]["cache_hit"] is False
+    assert second_loader.metadata["fetch"]["cache_hit"] is True
+    assert Path(first_loader.metadata["resolved_path"]).exists()
+
+
+def test_remote_loader_refresh_forces_redownload(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Refreshing a cached URL re-downloads and replaces the local cache entry."""
+    payloads = iter(
+        (
+            _catalogue_bytes(((30.0, 20.0, 0.1),)),
+            _catalogue_bytes(((40.0, 28.0, 0.3),)),
+        )
+    )
+    calls = 0
+
+    def fake_urlopen(request, *, timeout: int) -> _MockResponse:
+        nonlocal calls
+        calls += 1
+        return _MockResponse(next(payloads))
+
+    monkeypatch.setattr(_fetch, "urlopen", fake_urlopen)
+
+    url = "https://example.com/population.csv"
+    first_loader = FilePopulationLoader("bbh", url, cache_dir=tmp_path)
+    refreshed_loader = FilePopulationLoader("bbh", url, cache_dir=tmp_path, refresh=True)
+
+    assert calls == 2
+    assert first_loader.metadata["fetch"]["cache_hit"] is False
+    assert refreshed_loader.metadata["fetch"]["cache_hit"] is False
+    assert Path(refreshed_loader.metadata["resolved_path"]).read_text(encoding="utf-8").startswith("m1,m2,z\n40.0")
+
+
+def test_remote_loader_uses_environment_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Remote fetches pick up bearer tokens from the documented environment variable."""
+    seen_authorization_header: list[str | None] = []
+
+    def fake_urlopen(request, *, timeout: int) -> _MockResponse:
+        seen_authorization_header.append(request.headers.get("Authorization"))
+        return _MockResponse(_catalogue_bytes())
+
+    monkeypatch.setattr(_fetch, "urlopen", fake_urlopen)
+    monkeypatch.setenv("GWMOCK_POP_TOKEN", "secret-token")
+
+    FilePopulationLoader("bbh", "https://example.com/protected.csv", cache_dir=tmp_path)
+
+    assert seen_authorization_header == ["Bearer secret-token"]
+
+
+def test_remote_loader_surfaces_http_auth_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """HTTP authentication failures are raised as typed fetch errors."""
+
+    def fake_urlopen(request, *, timeout: int) -> _MockResponse:
+        raise HTTPError(request.full_url, 401, "Unauthorized", hdrs=None, fp=None)
+
+    monkeypatch.setattr(_fetch, "urlopen", fake_urlopen)
+
+    with pytest.raises(PopulationFetchError, match=r"HTTP 401 Unauthorized"):
+        FilePopulationLoader("bbh", "https://example.com/protected.csv", cache_dir=tmp_path)

--- a/tests/loaders/test_validation.py
+++ b/tests/loaders/test_validation.py
@@ -1,0 +1,87 @@
+"""Unit tests for CBC population validation and canonicalization."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from gwmock_pop import FilePopulationLoader, PopulationValidationError
+
+
+def _write_csv_catalogue(path: Path, rows: list[dict[str, float]]) -> None:
+    """Write a small header-based CSV catalogue."""
+    column_names = list(rows[0])
+    matrix = np.column_stack([[row[name] for row in rows] for name in column_names])
+    np.savetxt(path, matrix, delimiter=",", header=",".join(column_names), comments="")
+
+
+def test_loader_canonicalizes_cbc_aliases_and_derives_detector_masses(tmp_path: Path) -> None:
+    """CBC aliases are mapped and detector-frame masses are derived before sampling."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(
+        path,
+        [
+            {"m1_source": 24.0, "m2_source": 19.0, "z": 0.05, "tc": 50.0},
+            {"m1_source": 28.0, "m2_source": 23.0, "z": 0.10, "tc": 100.0},
+        ],
+    )
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(2, seed=0)
+
+    assert "detector_frame_mass_1" in loader.parameter_names
+    assert "detector_frame_mass_2" in loader.parameter_names
+    assert "coa_time" in loader.parameter_names
+    assert "source_frame_mass_1" not in loader.parameter_names
+    np.testing.assert_allclose(
+        np.sort(np.asarray(result["detector_frame_mass_1"])),
+        np.array([24.0 * 1.05, 28.0 * 1.10]),
+    )
+    np.testing.assert_allclose(
+        np.sort(np.asarray(result["detector_frame_mass_2"])),
+        np.array([19.0 * 1.05, 23.0 * 1.10]),
+    )
+
+
+def test_loader_rejects_unknown_cbc_columns_with_context(tmp_path: Path) -> None:
+    """Unknown CBC column names fail with a message that names the offending column."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(
+        path,
+        [
+            {"detector_frame_mass_1": 30.0, "detector_frame_mass_2": 20.0, "mystery_mass": 5.0},
+        ],
+    )
+
+    with pytest.raises(PopulationValidationError, match="mystery_mass"):
+        FilePopulationLoader("bbh", path)
+
+
+def test_loader_rejects_missing_mass_inputs_with_context(tmp_path: Path) -> None:
+    """Missing mass inputs fail with an actionable validation error."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(
+        path,
+        [
+            {"z": 0.1, "tc": 100.0},
+        ],
+    )
+
+    with pytest.raises(PopulationValidationError, match="detector_frame_mass_1"):
+        FilePopulationLoader("bbh", path)
+
+
+def test_loader_rejects_non_finite_values_with_context(tmp_path: Path) -> None:
+    """NaN and inf values fail before the loader can sample from the catalogue."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(
+        path,
+        [
+            {"detector_frame_mass_1": np.nan, "detector_frame_mass_2": 20.0},
+        ],
+    )
+
+    with pytest.raises(PopulationValidationError, match="detector_frame_mass_1"):
+        FilePopulationLoader("bbh", path)

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -29,7 +29,7 @@ def test_basic_import() -> None:
 def test_cli_help() -> None:
     """Test CLI help."""
     # Ensure the 'gwmock-pop' command was registered and runs
-    result = subprocess.run(["gwmock-pop", "--help"], capture_output=True, text=True, check=False)
+    result = subprocess.run(["gwmock-pop", "--help"], capture_output=True, text=True, check=False)  # noqa: S607
     assert result.returncode == 0
     assert "usage:" in result.stdout.lower()
 

--- a/uv.lock
+++ b/uv.lock
@@ -117,21 +117,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -431,7 +416,6 @@ build = [
 ]
 dev = [
     { name = "astropy" },
-    { name = "bandit" },
     { name = "hypothesis" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -462,7 +446,6 @@ requires-dist = [
 build = [{ name = "hatch", specifier = ">=1.16.5" }]
 dev = [
     { name = "astropy", specifier = ">=7.2.0" },
-    { name = "bandit", extras = ["toml"], specifier = ">=1.9.4" },
     { name = "hypothesis", specifier = ">=6.152.4" },
     { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=9.0.3" },
@@ -1587,15 +1570,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
-]
-
-[[package]]
-name = "stevedore"
-version = "5.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support remote population catalogues (HTTP(S), S3, Zenodo) with deterministic local caching, fetch metadata, and optional refresh
  * Catalogue validation and CBC parameter canonicalization with automatic detector-frame mass derivation
  * New public exception types for clearer error reporting

* **Documentation**
  * README and API docs updated to describe remote/catalogue caching and normalization

* **Tests**
  * Added tests for remote fetching, caching, auth, and validation

* **Chores**
  * Removed bandit; expanded Ruff security rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->