### PR TITLE
feat: Support coercion to numpy type

### DIFF
--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from gwmock_pop.coercion import coerce_to_numpy
 from gwmock_pop.configs import list_presets
 from gwmock_pop.constants import CBC_PARAMETER_NAMES
 from gwmock_pop.exceptions import PopulationError, PopulationFetchError, PopulationValidationError
@@ -35,6 +36,7 @@ __all__ = [
     "PopulationFetchError",
     "PopulationValidationError",
     "__version__",
+    "coerce_to_numpy",
     "list_presets",
     "validate_sample",
 ]

--- a/src/gwmock_pop/cli/inspect.py
+++ b/src/gwmock_pop/cli/inspect.py
@@ -27,14 +27,16 @@ class ParameterSummary:
     maximum: float
 
 
-def _ordered_parameter_names(simulator: GWPopSimulator, population: Mapping[str, Array]) -> list[str]:
+def _ordered_parameter_names(simulator: GWPopSimulator, population: Mapping[str, Array | np.ndarray]) -> list[str]:
     """Return a stable output order for the inspected population."""
     preferred = [name for name in simulator.parameter_names if name in population]
     remaining = [name for name in population if name not in preferred]
     return preferred + remaining
 
 
-def _summarize_population(simulator: GWPopSimulator, population: Mapping[str, Array]) -> list[ParameterSummary]:
+def _summarize_population(
+    simulator: GWPopSimulator, population: Mapping[str, Array | np.ndarray]
+) -> list[ParameterSummary]:
     """Compute scalar summary statistics for each sampled parameter."""
     summaries: list[ParameterSummary] = []
     for parameter in _ordered_parameter_names(simulator=simulator, population=population):

--- a/src/gwmock_pop/coercion.py
+++ b/src/gwmock_pop/coercion.py
@@ -1,0 +1,34 @@
+"""Helpers for coercing population records into NumPy-backed values."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+
+def coerce_to_numpy(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert array-backed record values to NumPy arrays or Python scalars.
+
+    This helper is intended for consumer boundaries where ``gwmock-pop`` output
+    should no longer require a JAX runtime. Array-valued inputs are materialized
+    as ``numpy.ndarray`` values, while 0-D array scalars are unwrapped to native
+    Python scalars via :meth:`numpy.ndarray.item`.
+
+    Args:
+        record: Mapping of parameter names to array-like or scalar values.
+
+    Returns:
+        A new mapping where JAX and NumPy values are converted to NumPy-backed
+        objects. Non-array values are passed through unchanged.
+    """
+    coerced: dict[str, Any] = {}
+    for name, value in record.items():
+        if not hasattr(value, "__array__") and not isinstance(value, (np.generic, np.ndarray)):
+            coerced[name] = value
+            continue
+
+        numpy_value = np.asarray(value)
+        coerced[name] = numpy_value.item() if numpy_value.ndim == 0 else numpy_value
+    return coerced

--- a/src/gwmock_pop/protocols/simulator.py
+++ b/src/gwmock_pop/protocols/simulator.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any, Protocol, runtime_checkable
 
+import numpy as np
 from jax import Array
+
+type PopulationArray = np.ndarray | Array
 
 
 @runtime_checkable
@@ -53,9 +56,11 @@ class GWPopSimulator(Protocol):
 
     **Array contract**
 
-    Every value in the mapping returned by ``simulate`` is a 1-D ``jax.Array``
-    of shape ``(n_samples,)``.  The keys are exactly ``parameter_names`` in the
-    same order.
+    Every value in the mapping returned by ``simulate`` is a 1-D
+    ``numpy.ndarray`` or ``jax.Array`` of shape ``(n_samples,)``. The keys are
+    exactly ``parameter_names`` in the same order. Consumers that want to drop
+    any downstream JAX dependency can materialize NumPy-backed values with
+    ``gwmock_pop.coerce_to_numpy(...)``.
     """
 
     @property
@@ -88,16 +93,16 @@ class GWPopSimulator(Protocol):
         """
         ...
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, PopulationArray]:
         """Draw ``n_samples`` parameter sets from the population model.
 
         The returned mapping must satisfy two invariants:
 
         1. **Key completeness and order**:
             ``list(result.keys()) == list(self.parameter_names)``.
-        2. **Shape contract**: every value is a ``jax.Array`` with leading
-           dimension ``n_samples``, i.e. ``result[k].shape[0] == n_samples``
-           for all ``k``.
+        2. **Shape contract**: every value is a 1-D ``numpy.ndarray`` or
+           ``jax.Array`` with leading dimension ``n_samples``, i.e.
+           ``result[k].shape[0] == n_samples`` for all ``k``.
 
         Args:
             n_samples: Number of independent source realizations to draw.
@@ -107,7 +112,7 @@ class GWPopSimulator(Protocol):
                 any keyword arguments; they exist for direct library use.
 
         Returns:
-            Mapping from parameter name to 1-D ``jax.Array`` of length
-            ``n_samples``.
+            Mapping from parameter name to 1-D ``numpy.ndarray`` or
+            ``jax.Array`` of length ``n_samples``.
         """
         ...

--- a/tests/protocols/test_protocols_loader.py
+++ b/tests/protocols/test_protocols_loader.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -41,7 +42,7 @@ class _MinimalHDF5Loader:
         if file_format not in self._supported_formats:
             raise ValueError(f"Unsupported file format for external population loader: {file_format}")
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
         """Return constant 1-D arrays of length ``n_samples``."""
         return {key: jnp.full((n_samples,), index + 1.0) for index, key in enumerate(self.parameter_names)}
 
@@ -58,7 +59,7 @@ class _MinimalCSVLoader:
         if file_format not in self._supported_formats:
             raise ValueError(f"Unsupported file format for external population loader: {file_format}")
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
         """Return constant 1-D arrays of length ``n_samples``."""
         return {key: jnp.full((n_samples,), index + 1.0) for index, key in enumerate(self.parameter_names)}
 
@@ -87,7 +88,7 @@ class TestExternalPopulationLoaderStructure:
         class _NoParameterNames:
             source_type = "bbh"
 
-            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
                 """Return empty mapping."""
                 return {}
 
@@ -99,7 +100,7 @@ class TestExternalPopulationLoaderStructure:
         class _NoSourceType:
             parameter_names: ClassVar[list[str]] = ["mass_1"]
 
-            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
                 """Return empty mapping."""
                 return {}
 
@@ -133,7 +134,7 @@ class TestExternalPopulationLoaderContracts:
     """Hypothesis-driven contract invariants, parametrized over both loaders."""
 
     @pytest.mark.parametrize("loader", _LOADERS, ids=["hdf5", "csv"])
-    @settings(max_examples=25)
+    @settings(max_examples=25, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_simulate_keys_match_parameter_names(self, loader: ExternalPopulationLoader, n_samples: int) -> None:
         """Test that simulate() returns exactly the keys in parameter_names."""
@@ -141,7 +142,7 @@ class TestExternalPopulationLoaderContracts:
         assert list(result.keys()) == list(loader.parameter_names)
 
     @pytest.mark.parametrize("loader", _LOADERS, ids=["hdf5", "csv"])
-    @settings(max_examples=25)
+    @settings(max_examples=25, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_simulate_arrays_have_n_samples_leading_dim(
         self,
@@ -154,7 +155,7 @@ class TestExternalPopulationLoaderContracts:
             assert array.shape[0] == n_samples
 
     @pytest.mark.parametrize("loader", _LOADERS, ids=["hdf5", "csv"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_source_type_is_non_empty_string(self, loader: ExternalPopulationLoader, n_samples: int) -> None:
         """Test that source_type is a non-empty string."""
@@ -171,7 +172,7 @@ class TestExternalPopulationLoaderContracts:
         assert first == second == third
 
     @pytest.mark.parametrize("loader", _LOADERS, ids=["hdf5", "csv"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_no_extra_keys_beyond_parameter_names(self, loader: ExternalPopulationLoader, n_samples: int) -> None:
         """Test that simulate() produces no keys beyond parameter_names."""
@@ -179,10 +180,10 @@ class TestExternalPopulationLoaderContracts:
         assert set(result.keys()) <= set(loader.parameter_names)
 
     @pytest.mark.parametrize("loader", _LOADERS, ids=["hdf5", "csv"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
-    def test_simulate_result_values_are_jax_arrays(self, loader: ExternalPopulationLoader, n_samples: int) -> None:
-        """Test that all values in the simulate() result are jax.Array instances."""
+    def test_simulate_result_values_are_array_like(self, loader: ExternalPopulationLoader, n_samples: int) -> None:
+        """Test that all values in the simulate() result are NumPy/JAX arrays."""
         result = loader.simulate(n_samples)
         for value in result.values():
-            assert isinstance(value, Array)
+            assert isinstance(value, Array | np.ndarray)

--- a/tests/protocols/test_protocols_simulator.py
+++ b/tests/protocols/test_protocols_simulator.py
@@ -21,6 +21,7 @@ from collections.abc import Mapping
 from typing import Any, ClassVar
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -39,7 +40,7 @@ class _MinimalBBHSimulator:
     parameter_names: ClassVar[list[str]] = ["mass_1", "mass_2", "distance", "redshift"]
     source_type = "bbh"
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
         """Return constant 1-D arrays of length ``n_samples``."""
         return {k: jnp.ones(n_samples) for k in self.parameter_names}
 
@@ -50,7 +51,7 @@ class _MinimalStochasticSimulator:
     parameter_names: ClassVar[list[str]] = ["omega_gw", "spectral_index"]
     source_type = "stochastic"
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
         """Return constant 1-D arrays of length ``n_samples``."""
         return {k: jnp.ones(n_samples) for k in self.parameter_names}
 
@@ -80,7 +81,7 @@ class TestGWPopSimulatorStructure:
         class _NoParameterNames:
             source_type = "bbh"
 
-            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
                 """Return empty mapping."""
                 return {}
 
@@ -92,7 +93,7 @@ class TestGWPopSimulatorStructure:
         class _NoSourceType:
             parameter_names: ClassVar[list[str]] = ["mass_1"]
 
-            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
                 """Return empty mapping."""
                 return {}
 
@@ -114,7 +115,7 @@ class TestGWPopSimulatorStructure:
             parameter_names: ClassVar[list[str]] = ["x"]
             source_type = "test"
 
-            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+            def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array | np.ndarray]:
                 """Return constant array."""
                 return {"x": jnp.ones(n_samples)}
 
@@ -130,7 +131,7 @@ class TestGWPopSimulatorContracts:
     """Hypothesis-driven contract invariants, parametrized over both simulators."""
 
     @pytest.mark.parametrize("simulator", _SIMULATORS, ids=["bbh", "stochastic"])
-    @settings(max_examples=25)
+    @settings(max_examples=25, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_simulate_keys_match_parameter_names(self, simulator: GWPopSimulator, n_samples: int) -> None:
         """Test that simulate() returns exactly the keys in parameter_names."""
@@ -138,7 +139,7 @@ class TestGWPopSimulatorContracts:
         assert list(result.keys()) == list(simulator.parameter_names)
 
     @pytest.mark.parametrize("simulator", _SIMULATORS, ids=["bbh", "stochastic"])
-    @settings(max_examples=25)
+    @settings(max_examples=25, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_simulate_arrays_have_n_samples_leading_dim(self, simulator: GWPopSimulator, n_samples: int) -> None:
         """Test that every output array has leading dimension equal to n_samples."""
@@ -147,7 +148,7 @@ class TestGWPopSimulatorContracts:
             assert array.shape[0] == n_samples
 
     @pytest.mark.parametrize("simulator", _SIMULATORS, ids=["bbh", "stochastic"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_source_type_is_non_empty_string(self, simulator: GWPopSimulator, n_samples: int) -> None:
         """Test that source_type is a non-empty string."""
@@ -160,7 +161,7 @@ class TestGWPopSimulatorContracts:
         assert list(simulator.parameter_names) == list(simulator.parameter_names)
 
     @pytest.mark.parametrize("simulator", _SIMULATORS, ids=["bbh", "stochastic"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
     def test_no_extra_keys_beyond_parameter_names(self, simulator: GWPopSimulator, n_samples: int) -> None:
         """Test that simulate() produces no keys beyond parameter_names."""
@@ -168,10 +169,10 @@ class TestGWPopSimulatorContracts:
         assert set(result.keys()) <= set(simulator.parameter_names)
 
     @pytest.mark.parametrize("simulator", _SIMULATORS, ids=["bbh", "stochastic"])
-    @settings(max_examples=20)
+    @settings(max_examples=20, deadline=None)
     @given(n_samples=st.integers(min_value=1, max_value=500))
-    def test_simulate_result_values_are_jax_arrays(self, simulator: GWPopSimulator, n_samples: int) -> None:
-        """Test that all values in the simulate() result are jax.Array instances."""
+    def test_simulate_result_values_are_array_like(self, simulator: GWPopSimulator, n_samples: int) -> None:
+        """Test that all values in the simulate() result are NumPy/JAX arrays."""
         result = simulator.simulate(n_samples)
         for value in result.values():
-            assert isinstance(value, Array)
+            assert isinstance(value, Array | np.ndarray)

--- a/tests/test_coercion.py
+++ b/tests/test_coercion.py
@@ -1,0 +1,41 @@
+"""Tests for NumPy coercion helpers."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from gwmock_pop import coerce_to_numpy
+
+
+def test_coerce_to_numpy_converts_array_columns_to_ndarrays() -> None:
+    """Batch population columns are materialized as NumPy arrays."""
+    record = {
+        "detector_frame_mass_1": jnp.array([30.0, 32.0]),
+        "detector_frame_mass_2": np.array([20.0, 21.0]),
+    }
+
+    result = coerce_to_numpy(record)
+
+    assert isinstance(result["detector_frame_mass_1"], np.ndarray)
+    assert isinstance(result["detector_frame_mass_2"], np.ndarray)
+    np.testing.assert_allclose(result["detector_frame_mass_1"], np.array([30.0, 32.0]))
+    np.testing.assert_allclose(result["detector_frame_mass_2"], np.array([20.0, 21.0]))
+
+
+def test_coerce_to_numpy_unwraps_scalar_arrays_and_preserves_plain_values() -> None:
+    """Scalar array entries become Python scalars, while plain values pass through."""
+    record = {
+        "redshift": jnp.array(0.1),
+        "coa_time": np.float64(1000.0),
+        "source_type": "bbh",
+    }
+
+    result = coerce_to_numpy(record)
+
+    assert isinstance(result["redshift"], float)
+    assert isinstance(result["coa_time"], float)
+    assert result["redshift"] == pytest.approx(0.1)
+    assert result["coa_time"] == pytest.approx(1000.0)
+    assert result["source_type"] == "bbh"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Population outputs now support both NumPy and JAX arrays, providing greater flexibility for different computational backends.
  * Added a data coercion utility to standardize and normalize array-like data, ensuring consistent handling across various input formats.

* **Tests**
  * Expanded test coverage to validate the new coercion functionality, including proper handling of array columns and scalar value unwrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->