### PR TITLE
fix(loader): Allow loading full catalogue

### DIFF
--- a/src/gwmock_pop/loaders/file_loader.py
+++ b/src/gwmock_pop/loaders/file_loader.py
@@ -220,11 +220,12 @@ class FilePopulationLoader:
         """Return loader metadata, including remote cache details when relevant."""
         return self._metadata
 
-    def simulate(self, n_samples: int, **kwargs: Any) -> Mapping[str, Array]:
+    def simulate(self, n_samples: int | None = None, **kwargs: Any) -> Mapping[str, Array]:
         """Sample catalogue rows without replacement.
 
         Args:
-            n_samples: Number of catalogue rows to draw.
+            n_samples: Number of catalogue rows to draw.  Pass ``None`` to
+                return all rows in the catalogue.
             **kwargs: Optional backend-agnostic random-state hints. Supported
                 keys include ``seed``, ``key``, and ``rng`` (in that priority).
 
@@ -237,6 +238,8 @@ class FilePopulationLoader:
                 rows in the loaded catalogue.
         """
         catalogue_size = len(next(iter(self._catalogue.values())))
+        if n_samples is None:
+            n_samples = catalogue_size
         if n_samples < 0:
             raise ValueError(f"n_samples must be >= 0, got {n_samples}.")
         if n_samples > catalogue_size:

--- a/tests/loaders/test_file_loader.py
+++ b/tests/loaders/test_file_loader.py
@@ -193,3 +193,48 @@ def test_unsupported_format_raises(tmp_path: Path) -> None:
 
     with pytest.raises(PopulationValidationError, match=r"Supported suffixes: \.csv, \.h5, \.hdf5"):
         FilePopulationLoader("bbh", path)
+
+
+def test_simulate_none_returns_all_rows(tmp_path: Path) -> None:
+    """simulate(n_samples=None) returns arrays whose length equals catalogue size."""
+    n_rows = 15
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(path, _catalogue_columns(n_rows=n_rows))
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(n_samples=None)
+
+    assert all(len(array) == n_rows for array in result.values())
+
+
+def test_simulate_none_returns_all_columns(tmp_path: Path) -> None:
+    """simulate(n_samples=None) returns all parameter_names keys."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(path, _catalogue_columns(n_rows=10))
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(n_samples=None)
+
+    assert set(result.keys()) == set(loader.parameter_names)
+
+
+def test_simulate_zero_returns_empty(tmp_path: Path) -> None:
+    """simulate(n_samples=0) returns empty arrays without raising."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(path, _catalogue_columns(n_rows=10))
+
+    loader = FilePopulationLoader("bbh", path)
+    result = loader.simulate(n_samples=0)
+
+    assert all(len(array) == 0 for array in result.values())
+
+
+def test_simulate_negative_still_raises(tmp_path: Path) -> None:
+    """simulate(n_samples=-1) still raises ValueError after the signature change."""
+    path = tmp_path / "catalogue.csv"
+    _write_csv_catalogue(path, _catalogue_columns(n_rows=10))
+
+    loader = FilePopulationLoader("bbh", path)
+
+    with pytest.raises(ValueError, match=r"n_samples must be >= 0"):
+        loader.simulate(n_samples=-1)


### PR DESCRIPTION
Close #254 

Adds `n_samples=None` support to `FilePopulationLoader.simulate()` so callers can retrieve the full catalogue without needing to know its size upfront.

### Changes

**`src/gwmock_pop/loaders/file_loader.py`**
- Signature: `simulate(self, n_samples: int | None = None, ...)` 
- Added `None` branch before existing guards: when `None`, sets `n_samples = catalogue_size`
- No other changes to method body

**`tests/loaders/test_file_loader.py`** — 4 new integration tests:
- `test_simulate_none_returns_all_rows` — verifies all rows are returned
- `test_simulate_none_returns_all_columns` — verifies all parameter keys are present
- `test_simulate_zero_returns_empty` — verifies `simulate(0)` returns empty arrays
- `test_simulate_negative_still_raises` — verifies existing `-1` raises `ValueError`

### Test Results

- 720 unit tests: all pass
- 13 file-loader integration tests: all pass
- `ruff check` / `ruff format`: clean
- Total coverage: 86%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sample parameter in population simulation now accepts optional input with a default behavior. When unspecified, all available catalogue rows are automatically loaded.

* **Tests**
  * Added integration tests validating edge cases: full catalogue loading, parameter completeness, empty array handling for zero samples, and rejection of negative values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Leuven-Gravity-Institute/gwmock-pop/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->