### PR TITLE
fix: export catalogue I/O helpers at the top level

### DIFF
--- a/src/gwmock_pop/__init__.py
+++ b/src/gwmock_pop/__init__.py
@@ -6,7 +6,7 @@ from gwmock_pop.coercion import coerce_to_numpy
 from gwmock_pop.configs import list_presets
 from gwmock_pop.constants import CBC_PARAMETER_NAMES
 from gwmock_pop.exceptions import PopulationError, PopulationFetchError, PopulationValidationError
-from gwmock_pop.loaders import FilePopulationLoader
+from gwmock_pop.loaders import FilePopulationLoader, read_population_catalogue, write_population_catalogue
 from gwmock_pop.protocols import ExternalPopulationLoader, GWPopSimulator
 from gwmock_pop.simulators import (
     BBHSimulator,
@@ -38,5 +38,7 @@ __all__ = [
     "__version__",
     "coerce_to_numpy",
     "list_presets",
+    "read_population_catalogue",
     "validate_sample",
+    "write_population_catalogue",
 ]

--- a/src/gwmock_pop/loaders/__init__.py
+++ b/src/gwmock_pop/loaders/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
-from gwmock_pop.loaders.file_loader import FilePopulationLoader
+from gwmock_pop.loaders.file_loader import (
+    FilePopulationLoader,
+    read_population_catalogue,
+    write_population_catalogue,
+)
 
-__all__ = ["FilePopulationLoader"]
+__all__ = ["FilePopulationLoader", "read_population_catalogue", "write_population_catalogue"]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -29,6 +29,26 @@ def test_import_main_package():
     assert gwmock_pop.__version__ is not None
 
 
+def test_catalogue_io_exported_at_top_level():
+    """Regression: the README documents these as top-level exports.
+
+    In v0.10.2 they were only importable from the private
+    ``gwmock_pop.loaders.file_loader`` module.
+    """
+    from gwmock_pop import read_population_catalogue, write_population_catalogue
+    from gwmock_pop.loaders import (
+        read_population_catalogue as loaders_read,
+    )
+    from gwmock_pop.loaders import (
+        write_population_catalogue as loaders_write,
+    )
+
+    assert read_population_catalogue is loaders_read
+    assert write_population_catalogue is loaders_write
+    assert "read_population_catalogue" in gwmock_pop.__all__
+    assert "write_population_catalogue" in gwmock_pop.__all__
+
+
 @pytest.mark.parametrize("module_name", get_all_submodules(gwmock_pop))
 def test_import_submodule(module_name):
     """Test that all submodules can be imported."""


### PR DESCRIPTION
## Summary

The README documents `read_population_catalogue` / `write_population_catalogue` as public API, but in v0.10.2:

```python
from gwmock_pop import write_population_catalogue          # ImportError
from gwmock_pop.loaders import write_population_catalogue  # ImportError
from gwmock_pop.loaders.file_loader import write_population_catalogue  # only this worked
```

Re-exports both helpers from `gwmock_pop.loaders` and the package top level (added to `__all__`), with a regression test asserting the documented import paths resolve to the same objects.

Found while preparing the Leuven GW Workshop notebooks against released 0.10.2. Note: this branch is independent of #308; both touch `src/gwmock_pop/__init__.py` in disjoint hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)