### PR TITLE
docs: add README preset example; statement of need as a docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@
 `gwmock-pop` is a Python package for simulating populations of
 gravitational-wave sources.
 
+## Statement of need
+
+Building the source population for a gravitational-wave mock data challenge
+usually means bespoke sampling scripts that are hard to reproduce and hard to
+reconfigure when priors change. `gwmock-pop` is the _forward_ counterpart to
+population-inference tools such as `gwpopulation`: instead of inferring
+hyper-parameters from observed events, it draws synthetic catalogues from
+configurable priors. Its graph-driven sampler lets users declare arbitrary
+parameter-dependency structures in YAML/TOML — validated without executing
+arbitrary Python — and ships presets reflecting recent observed populations. It
+is the population layer of the `gwmock` mock-data-challenge ecosystem, usable
+standalone or through the `gwmock` orchestrator, and scales to the catalogue
+sizes (of order 10⁵ sources per year) expected from next-generation detectors
+such as the Einstein Telescope.
+
 ## Current package surface
 
 - **Protocols:** `GWPopSimulator` (population simulators),
@@ -124,6 +139,17 @@ assert population["detector_frame_mass_1"].shape == (100,)
 
 Use `GraphSimulator.from_config_file(...)` or `GraphSimulator.from_preset(...)`
 for full graph configs (see `examples/` and `gwmock_pop.simulators.graph`).
+
+Sample from a packaged preset (run `gwmock-pop list` or `list_presets()` for the
+available names):
+
+```python
+from gwmock_pop import GraphSimulator, list_presets
+
+print(list_presets())                 # e.g. ["gwtc4", ...]
+sim = GraphSimulator.from_preset("gwtc4")
+catalogue = sim.simulate(1000)
+```
 
 `FilePopulationLoader` also accepts `http://`, `https://`, `s3://`, and
 `zenodo://<record>/<file>` sources. Remote catalogues are cached under

--- a/README.md
+++ b/README.md
@@ -14,21 +14,6 @@
 `gwmock-pop` is a Python package for simulating populations of
 gravitational-wave sources.
 
-## Statement of need
-
-Building the source population for a gravitational-wave mock data challenge
-usually means bespoke sampling scripts that are hard to reproduce and hard to
-reconfigure when priors change. `gwmock-pop` is the _forward_ counterpart to
-population-inference tools such as `gwpopulation`: instead of inferring
-hyper-parameters from observed events, it draws synthetic catalogues from
-configurable priors. Its graph-driven sampler lets users declare arbitrary
-parameter-dependency structures in YAML/TOML — validated without executing
-arbitrary Python — and ships presets reflecting recent observed populations. It
-is the population layer of the `gwmock` mock-data-challenge ecosystem, usable
-standalone or through the `gwmock` orchestrator, and scales to the catalogue
-sizes (of order 10⁵ sources per year) expected from next-generation detectors
-such as the Einstein Telescope.
-
 ## Current package surface
 
 - **Protocols:** `GWPopSimulator` (population simulators),

--- a/docs/statement-of-need.md
+++ b/docs/statement-of-need.md
@@ -1,0 +1,14 @@
+# Statement of need
+
+Building the source population for a gravitational-wave mock data challenge
+usually means bespoke sampling scripts that are hard to reproduce and hard to
+reconfigure when priors change. `gwmock-pop` is the _forward_ counterpart to
+population-inference tools such as `gwpopulation`: instead of inferring
+hyper-parameters from observed events, it draws synthetic catalogues from
+configurable priors. Its graph-driven sampler lets users declare arbitrary
+parameter-dependency structures in YAML/TOML — validated without executing
+arbitrary Python — and ships presets reflecting recent observed populations. It
+is the population layer of the `gwmock` mock-data-challenge ecosystem, usable
+standalone or through the `gwmock` orchestrator, and scales to the catalogue
+sizes (of order 10⁵ sources per year) expected from next-generation detectors
+such as the Einstein Telescope.

--- a/zensical.toml
+++ b/zensical.toml
@@ -51,6 +51,7 @@ Copyright &copy; 2026 Isaac C. F. Wong
 # Read more: https://zensical.org/docs/setup/navigation/
 nav = [
   { "Get Started" = "index.md" },
+  { "Statement of need" = "statement-of-need.md" },
   { "Installation" = "user_guide/installation.md" },
   { "User Guide" = [
     { "Quick Start" = "user_guide/quick_start.md" },


### PR DESCRIPTION
Part of the JOSS submission polish (`gwmock-joss/readme-polish`).

Keeps the README concise (most-important info only):
- **README:** add a packaged-preset library example (`list_presets` / `GraphSimulator.from_preset`).
- **Docs:** add a dedicated **Statement of need** page (`docs/statement-of-need.md`) with a nav entry, instead of putting it in the README. JOSS's Statement-of-need requirement is satisfied by `paper.md`; the docs page covers the review-checklist documentation item without bloating the README.

No code changes. Prettier + markdownlint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Statement of need” page describing the catalog-building workflow and overall capabilities at a high level.
  * Updated the library “Getting started” guide with a new Python example that lists available presets, loads one, and generates a sample catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->